### PR TITLE
Expand slider-bounded Σ/Π in the worker's graph analysis

### DIFF
--- a/worker/graph.ts
+++ b/worker/graph.ts
@@ -6,6 +6,7 @@
  * by using the exact same lib functions.
  */
 import {
+  animatedConstNames,
   buildDefs,
   compsOf,
   defKey,
@@ -127,6 +128,13 @@ export function analyze(texts: string[]): Analysis {
     if (!fn && fnNames.has(name)) throw new Error(`${name} has an error in its definition.`);
     return fn;
   };
+  // Σ/Π bounds in plot rows expand against the constants' values at t = 0, as
+  // in web/main.ts (animated constants and states excluded: expansion is
+  // static, so their bounds have no fixed value).
+  const boundVals = { ...constEnv };
+  for (const name of animatedConstNames(defs)) delete boundVals[name];
+  for (const name of defs.states.keys()) delete boundVals[name];
+  const ropts = { consts: boundVals, boundConsts: built.sumBoundConsts };
 
   // Random variables next, so P(…) and bare-expression rows can reference
   // them regardless of row order.
@@ -134,6 +142,7 @@ export function analyze(texts: string[]): Analysis {
   const builtRVs = buildRVSystem(rvs, rvScan, {
     fnNames,
     getFn,
+    ropts,
     constNames,
     taken: n => defs.consts.has(n) || defs.fns.has(n) || defs.fields.has(n)
       || defs.states.has(n) || defs.points.has(n) || defs.mats.has(n),
@@ -185,7 +194,7 @@ export function analyze(texts: string[]): Analysis {
       const probBody = defs.consts.has('P') || defs.fns.has('P') ? null : matchProbability(row.text);
       if (probBody !== null) {
         if (!rvNames.size) throw new Error('Define a random variable first, e.g. X ~ Normal(0, 1).');
-        const p = toProbability(resolveExpr(parseExpr(probBody, fnNames), getFn), rvNames);
+        const p = toProbability(resolveExpr(parseExpr(probBody, fnNames), getFn, ropts), rvNames);
         for (const name of p.rvs) {
           if (!rvs.has(name)) throw new Error(`${name} has an error in its definition.`);
         }
@@ -241,7 +250,7 @@ export function analyze(texts: string[]): Analysis {
       const expectBody = defs.consts.has('E') || defs.fns.has('E') ? null : matchExpectation(row.text);
       if (expectBody !== null) {
         if (!rvNames.size) throw new Error('Define a random variable first, e.g. X ~ Normal(0, 1).');
-        const ex = toExpectation(resolveExpr(parseExpr(expectBody, fnNames), getFn), rvNames);
+        const ex = toExpectation(resolveExpr(parseExpr(expectBody, fnNames), getFn, ropts), rvNames);
         for (const name of ex.rvs) {
           if (!rvs.has(name)) throw new Error(`${name} has an error in its definition.`);
         }
@@ -274,11 +283,11 @@ export function analyze(texts: string[]): Analysis {
       }
       const seq = scanSeqRec(row.text);
       if (seq) {
-        row.cls = classifySeqRec(seq, fnNames, getFn, constNames);
+        row.cls = classifySeqRec(seq, fnNames, getFn, constNames, ropts);
         continue;
       }
       const rawParsed = parseExpr(row.text, fnNames);
-      let parsed = resolveExpr(rawParsed, getFn);
+      let parsed = resolveExpr(rawParsed, getFn, ropts);
       // A bare expression in random variables plots that derived density.
       const rvRefs = [...freeVars(parsed)].filter(n => rvNames.has(n));
       if (rvRefs.length) {

--- a/worker/mcp.test.ts
+++ b/worker/mcp.test.ts
@@ -117,6 +117,28 @@ describe('mcp endpoint', () => {
     expect(out.preview_omits).toBeUndefined();
   });
 
+  it('expands slider-bounded sums like the app does (Fourier series)', async () => {
+    const { body } = await rpc('tools/call', {
+      name: 'create_graph',
+      arguments: { equations: ['N = 8', 'y = 2 sum[n=1..N] (-1)^(n+1) sin(n x)/n'] },
+    });
+    const out = body.result.structuredContent;
+    expect(out.valid).toBe(true);
+    expect(out.rows.map((r: { kind?: string }) => r.kind)).toEqual(['definition (const)', 'implicit2d']);
+    expect(out.preview_omits).toBeUndefined();
+  });
+
+  it('still rejects Σ bounds with no static value (animated constant)', async () => {
+    const { body } = await rpc('tools/call', {
+      name: 'create_graph',
+      arguments: { equations: ['a = 2 + sin(t)', 'y = sum[n=1..a] x^n'] },
+    });
+    const out = body.result.structuredContent;
+    expect(out.valid).toBe(false);
+    expect(out.rows[1].status).toBe('error');
+    expect(out.rows[1].error).toContain('must be constant');
+  });
+
   it('rejects a P(…) row with no random variable declared', async () => {
     const { body } = await rpc('tools/call', {
       name: 'create_graph',


### PR DESCRIPTION
## What

Rebased onto main (the random-variable worker support it was stacked on landed via #79). Fixes the parity gap: worker `analyze()` called `resolveExpr` with no `ResolveOpts`, so any Σ/Π whose bound is a constant from another row failed with "Σ bounds must be constant" through MCP `create_graph` and `/g/` previews — including the Fourier example llms.txt itself ships (`N = 8; y = 2 sum[n=1..N] (-1)^(n+1) sin(n x)/n`). The app expands these fine.

`analyze()` now builds the same options web/main.ts does — constants evaluated at t = 0, minus animated constants and states (expansion is static), plus the `sumBoundConsts` set `buildDefs` already returned but the worker discarded — and passes them to every `resolveExpr` call (plot rows, distribution mean/sd, `P(…)` bodies) and to `classifySeqRec`.

## Behavior

- `N = 8; y = 2 sum[n=1..N] …` → validates, classifies `implicit2d`, draws in the preview (Σ expands before compile, so the vm needs nothing new).
- Sums now also work inside distribution parameters (`X ~ Normal(sum[n=1..N] 1/n, 1)`; the P readout verifies against the normal CDF) and in sequence rows.
- Unchanged rejections, with the app's own messages: bounds on an animated constant ("Σ bounds must be constant — add \"a = 5\"…") and bounds on t ("Σ bounds cannot depend on t").

## Tests

Two new end-to-end `create_graph` cases: the Fourier example validates with nothing omitted from the preview, and the animated-constant bound still errors. 629 passing after the rebase (ropts is also wired into the post-#79 call sites: buildRVSystem and E(…) rows); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Migrated from equation-src#58 as part of the open-source move.*

