### PR TITLE
Tube checker in material coordinates (arclength × RMF angle)

### DIFF
--- a/lib/curve3d.test.ts
+++ b/lib/curve3d.test.ts
@@ -102,11 +102,12 @@ describe('buildTube', () => {
   it('places every ring vertex at the tube radius with unit normals', () => {
     const fr = curveFrames(helix.pts, helix.d1, helix.d2, helix.d3);
     const tube = buildTube(helix.pts, fr, 0.25, 16);
-    expect(tube.positions.length).toBe(N * 16 * 3);
+    const stride = 17; // duplicated seam column
+    expect(tube.positions.length).toBe(N * stride * 3);
     expect(tube.indices.length).toBe((N - 1) * 16 * 6);
     for (const i of [0, 57, 399]) {
-      for (let s = 0; s < 16; s++) {
-        const o = (i * 16 + s) * 3;
+      for (let s = 0; s < stride; s++) {
+        const o = (i * stride + s) * 3;
         const dx = tube.positions[o] - helix.pts[i * 3];
         const dy = tube.positions[o + 1] - helix.pts[i * 3 + 1];
         const dz = tube.positions[o + 2] - helix.pts[i * 3 + 2];
@@ -114,7 +115,7 @@ describe('buildTube', () => {
         expect(Math.hypot(tube.normals[o], tube.normals[o + 1], tube.normals[o + 2])).toBeCloseTo(1, 5);
       }
     }
-    for (const ix of tube.indices) expect(ix).toBeLessThan(N * 16);
+    for (const ix of tube.indices) expect(ix).toBeLessThan(N * stride);
   });
 
   it('drops triangles that touch invalid rings', () => {
@@ -124,9 +125,40 @@ describe('buildTube', () => {
     const tube = buildTube(pts, fr, 0.2, 8);
     expect(tube.indices.length).toBe((N - 1 - 2) * 8 * 6);
     for (const ix of tube.indices) {
-      const ring = Math.floor(ix / 8);
+      const ring = Math.floor(ix / 9);
       expect(ring).not.toBe(100);
     }
+  });
+
+  it('lays material coordinates along arclength and around the RMF ring', () => {
+    const fr = curveFrames(helix.pts, helix.d1, helix.d2, helix.d3);
+    const tube = buildTube(helix.pts, fr, 0.25, 16);
+    const stride = 17;
+    // Constant-speed helix: arclength fraction u is linear in the parameter.
+    for (const i of [0, 100, 399]) {
+      expect(tube.uvs[(i * stride) * 2]).toBeCloseTo(i / (N - 1), 3);
+    }
+    // Ring seam duplicates position but carries v = 1 instead of 0.
+    const i = 100;
+    expect(tube.uvs[(i * stride) * 2 + 1]).toBe(0);
+    expect(tube.uvs[(i * stride + 16) * 2 + 1]).toBeCloseTo(1, 6);
+    for (let c = 0; c < 3; c++) {
+      expect(tube.positions[(i * stride + 16) * 3 + c]).toBeCloseTo(tube.positions[(i * stride) * 3 + c], 5);
+    }
+  });
+
+  it('sizes checker cells to be square-ish and even around closed loops', () => {
+    const circle = sample(
+      u => [3 * Math.cos(2 * Math.PI * u), 3 * Math.sin(2 * Math.PI * u), 0],
+    );
+    const fr = curveFrames(circle.pts);
+    const tube = buildTube(circle.pts, fr, 0.25, 16);
+    const [lenCells, angCells] = tube.cells;
+    expect(angCells).toBe(8);
+    expect(lenCells % 2).toBe(0);
+    // Circumference 2π·3 against angular cell 2π·0.25/8: ~96 cells.
+    expect(lenCells).toBeGreaterThan(80);
+    expect(lenCells).toBeLessThan(110);
   });
 });
 

--- a/lib/curve3d.ts
+++ b/lib/curve3d.ts
@@ -217,8 +217,22 @@ export function curveFrames(
 export interface TubeMesh {
   positions: Float32Array;
   normals: Float32Array;
+  /**
+   * Material coordinates per vertex: x = arclength fraction along the curve,
+   * y = angle fraction around the ring (in the rotation-minimizing frame, so
+   * the coordinate does not spiral with torsion).
+   */
+  uvs: Float32Array;
   indices: Uint32Array;
+  /**
+   * Checker cell counts along (length, circumference) giving roughly square
+   * cells in world units — a pattern painted on the material, not on the
+   * parameter.
+   */
+  cells: [number, number];
 }
+
+const ANGULAR_CELLS = 8;
 
 /** Sweep a circle of `radius` along the curve using the rotation-minimizing frame. */
 export function buildTube(
@@ -228,21 +242,37 @@ export function buildTube(
   segments = 24,
 ): TubeMesh {
   const n = pts.length / 3;
-  const { normal, binormal } = frames;
-  const positions = new Float32Array(n * segments * 3);
-  const normals = new Float32Array(n * segments * 3);
-  const cos = new Float64Array(segments);
-  const sin = new Float64Array(segments);
-  for (let s = 0; s < segments; s++) {
-    cos[s] = Math.cos(2 * Math.PI * s / segments);
-    sin[s] = Math.sin(2 * Math.PI * s / segments);
+  const { normal, binormal, closed } = frames;
+  // Rings carry a duplicated seam column (angle 0 again as angle 1) so the
+  // material coordinate interpolates cleanly across the wrap.
+  const stride = segments + 1;
+  const positions = new Float32Array(n * stride * 3);
+  const normals = new Float32Array(n * stride * 3);
+  const uvs = new Float32Array(n * stride * 2);
+
+  // Cumulative arclength; steps through invalid samples contribute nothing.
+  const arc = new Float64Array(n);
+  for (let i = 1; i < n; i++) {
+    const j = i * 3;
+    const d = Math.hypot(pts[j] - pts[j - 3], pts[j + 1] - pts[j - 2], pts[j + 2] - pts[j - 1]);
+    arc[i] = arc[i - 1] + (isFinite(d) ? d : 0);
+  }
+  const total = arc[n - 1] > 0 ? arc[n - 1] : 1;
+
+  const cos = new Float64Array(stride);
+  const sin = new Float64Array(stride);
+  for (let s = 0; s < stride; s++) {
+    // s % segments keeps the seam column bit-identical to column 0.
+    cos[s] = Math.cos(2 * Math.PI * (s % segments) / segments);
+    sin[s] = Math.sin(2 * Math.PI * (s % segments) / segments);
   }
   const valid: boolean[] = new Array(n);
   for (let i = 0; i < n; i++) {
     const j = i * 3;
     valid[i] = finite3(pts, i) && finite3(normal, i) && finite3(binormal, i);
-    for (let s = 0; s < segments; s++) {
-      const o = (i * segments + s) * 3;
+    const u = arc[i] / total;
+    for (let s = 0; s < stride; s++) {
+      const o = (i * stride + s) * 3;
       const rx = cos[s] * normal[j] + sin[s] * binormal[j];
       const ry = cos[s] * normal[j + 1] + sin[s] * binormal[j + 1];
       const rz = cos[s] * normal[j + 2] + sin[s] * binormal[j + 2];
@@ -252,20 +282,33 @@ export function buildTube(
       positions[o] = pts[j] + radius * rx;
       positions[o + 1] = pts[j + 1] + radius * ry;
       positions[o + 2] = pts[j + 2] + radius * rz;
+      const q = (i * stride + s) * 2;
+      uvs[q] = u;
+      uvs[q + 1] = s / segments;
     }
   }
   const idx: number[] = [];
   for (let i = 0; i + 1 < n; i++) {
     if (!valid[i] || !valid[i + 1]) continue;
     for (let s = 0; s < segments; s++) {
-      const a = i * segments + s;
-      const b = i * segments + (s + 1) % segments;
-      const c = (i + 1) * segments + s;
-      const d = (i + 1) * segments + (s + 1) % segments;
-      idx.push(a, b, c, b, d, c);
+      const a = i * stride + s;
+      const c = (i + 1) * stride + s;
+      idx.push(a, a + 1, c, a + 1, c + 1, c);
     }
   }
-  return { positions, normals, indices: Uint32Array.from(idx) };
+
+  // Along-length cell size matched to the angular cell (2πr / ANGULAR_CELLS);
+  // on closed curves an even count makes the checker parity continue across
+  // the loop seam.
+  let lenCells = Math.max(2, Math.round(total / (2 * Math.PI * radius / ANGULAR_CELLS)));
+  if (closed && lenCells % 2) lenCells += 1;
+  return {
+    positions,
+    normals,
+    uvs,
+    indices: Uint32Array.from(idx),
+    cells: [lenCells, ANGULAR_CELLS],
+  };
 }
 
 export interface Comb {

--- a/web/main.ts
+++ b/web/main.ts
@@ -481,8 +481,7 @@ function render() {
           }
           const fr = curveFrames(pts, sampleDeriv(plot.d1), sampleDeriv(plot.d2), sampleDeriv(plot.d3));
           if (radius > 0) {
-            const { positions, normals, indices } = buildTube(pts, fr, radius, TUBE_SEGMENTS);
-            scene.tubes.push({ positions, normals, indices, color });
+            scene.tubes.push({ ...buildTube(pts, fr, radius, TUBE_SEGMENTS), color });
           } else {
             scene.curves.push({ pts, color });
           }

--- a/web/render3d.ts
+++ b/web/render3d.ts
@@ -248,16 +248,21 @@ void main() {
 `;
 }
 
-/** CPU-built tube meshes (curve framing): plain position+normal lighting. */
+/** CPU-built tube meshes (curve framing): position+normal lighting with a
+ * material checker in (arclength × ring angle) coordinates, the same faint
+ * grid parametric surfaces get — but painted on the tube's own material. */
 const TUBE_VERT = `#version 300 es
 layout(location=0) in vec3 aPos;
 layout(location=1) in vec3 aNormal;
+layout(location=2) in vec2 aUV;
 uniform mat4 uVP;
 out vec3 vPos;
 out vec3 vNormal;
+out vec2 vUV;
 void main() {
   vPos = aPos;
   vNormal = aNormal;
+  vUV = aUV;
   gl_Position = uVP * vec4(aPos, 1.0);
 }
 `;
@@ -266,8 +271,10 @@ const TUBE_FRAG = `#version 300 es
 precision highp float;
 uniform vec3 uColor;
 uniform vec3 uEye;
+uniform vec2 uCells;
 in vec3 vPos;
 in vec3 vNormal;
+in vec2 vUV;
 out vec4 outColor;
 void main() {
   vec3 n = normalize(vNormal);
@@ -282,7 +289,17 @@ void main() {
   float spec = pow(max(dot(n, halfway), 0.0), 96.0);
   float fresnel = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
 
-  vec3 col = uColor * (0.26 + 0.22 * sky + 0.46 * diffuse)
+  // Material checker: cells are square-ish in world units and follow the
+  // rotation-minimizing frame, so the pattern reads as painted on the tube.
+  float checker = mod(floor(min(vUV.x, 0.9999) * uCells.x) + floor(min(vUV.y, 0.9999) * uCells.y), 2.0);
+  // Fade to the average shade once cells shrink toward pixel size, so distant
+  // or thin tubes don't moiré.
+  vec2 cw = fwidth(vUV * uCells);
+  checker = mix(checker, 0.5, clamp(max(cw.x, cw.y) * 1.5 - 0.25, 0.0, 1.0));
+  // Slightly stronger than the psurface checker: tube cells are far smaller.
+  vec3 base = uColor * (0.88 + 0.12 * checker);
+
+  vec3 col = base * (0.26 + 0.22 * sky + 0.46 * diffuse)
            + vec3(1.0) * spec * 0.7
            + vec3(0.35, 0.4, 0.5) * fresnel * 0.3;
   outColor = vec4(col, 1.0);
@@ -393,11 +410,15 @@ export interface Scene3D {
   curves: Array<{ pts: Float32Array; color: [number, number, number] }>;
   /** Disconnected segments (comb teeth), drawn as gl.LINES vertex pairs. */
   segments: Array<{ pts: Float32Array; color: [number, number, number] }>;
-  /** Indexed position+normal meshes (curve tubes). */
+  /** Indexed position+normal meshes (curve tubes) with material UVs. */
   tubes: Array<{
     positions: Float32Array;
     normals: Float32Array;
+    /** Per-vertex (arclength fraction, ring-angle fraction). */
+    uvs: Float32Array;
     indices: Uint32Array;
+    /** Checker cell counts along (length, circumference). */
+    cells: [number, number];
     color: [number, number, number];
   }>;
   points: Array<{ pos: [number, number, number]; color: [number, number, number] }>;
@@ -417,6 +438,7 @@ export class Renderer3D {
   private tubeVao: WebGLVertexArrayObject;
   private tubePosBuf: WebGLBuffer;
   private tubeNrmBuf: WebGLBuffer;
+  private tubeUvBuf: WebGLBuffer;
   private tubeIdxBuf: WebGLBuffer;
   private gridVao: WebGLVertexArrayObject;
   private gridIndexCount: number;
@@ -434,11 +456,12 @@ export class Renderer3D {
     gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
     gl.bindVertexArray(null);
 
-    // Dynamic indexed mesh (curve tubes): separate position/normal buffers.
+    // Dynamic indexed mesh (curve tubes): separate position/normal/uv buffers.
     this.tubeProgram = compileProgram(gl, TUBE_VERT, TUBE_FRAG);
     this.tubeVao = gl.createVertexArray()!;
     this.tubePosBuf = gl.createBuffer()!;
     this.tubeNrmBuf = gl.createBuffer()!;
+    this.tubeUvBuf = gl.createBuffer()!;
     this.tubeIdxBuf = gl.createBuffer()!;
     gl.bindVertexArray(this.tubeVao);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.tubePosBuf);
@@ -447,6 +470,9 @@ export class Renderer3D {
     gl.bindBuffer(gl.ARRAY_BUFFER, this.tubeNrmBuf);
     gl.enableVertexAttribArray(1);
     gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.tubeUvBuf);
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 2, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.tubeIdxBuf);
     gl.bindVertexArray(null);
 
@@ -576,11 +602,14 @@ export class Renderer3D {
       setCommon(this.tubeProgram);
       gl.uniform3f(gl.getUniformLocation(this.tubeProgram, 'uColor'), ...tube.color);
       gl.uniform3f(gl.getUniformLocation(this.tubeProgram, 'uEye'), ...eye);
+      gl.uniform2f(gl.getUniformLocation(this.tubeProgram, 'uCells'), ...tube.cells);
       gl.bindVertexArray(this.tubeVao);
       gl.bindBuffer(gl.ARRAY_BUFFER, this.tubePosBuf);
       gl.bufferData(gl.ARRAY_BUFFER, tube.positions, gl.DYNAMIC_DRAW);
       gl.bindBuffer(gl.ARRAY_BUFFER, this.tubeNrmBuf);
       gl.bufferData(gl.ARRAY_BUFFER, tube.normals, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.tubeUvBuf);
+      gl.bufferData(gl.ARRAY_BUFFER, tube.uvs, gl.DYNAMIC_DRAW);
       gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, tube.indices, gl.DYNAMIC_DRAW);
       gl.drawElements(gl.TRIANGLES, tube.indices.length, gl.UNSIGNED_INT, 0);
       gl.bindVertexArray(null);


### PR DESCRIPTION
Stacked on #5. The tube's checker now lives in the tube's **own material coordinates** — cumulative arclength along the curve × ring angle in the rotation-minimizing frame — instead of being absent (or, as on parametric surfaces, living in parameter space). The pattern reads as if printed on the material: cells stay square-ish in world units, scale with the radius slider, follow the frame around bends without spiraling, and visibly compress on the inside of curves — which is real geometry, not an artifact (a tube around a bent centerline has nonzero Gaussian curvature, so a perfectly undistorted grid is impossible; the distortion *is* the surface angle information).

**Try it live** (crank the tube slider up to see the material scale):
- [Trefoil knot](https://claude-knot-tube-material-grid-equation.anthony-75d.workers.dev/#tube((sin(2pi%20u)%20%2B%202sin(4pi%20u)%2C%20cos(2pi%20u)%20-%202cos(4pi%20u)%2C%20-sin(6pi%20u))))
- [Helix](https://claude-knot-tube-material-grid-equation.anthony-75d.workers.dev/#tube((2cos(6pi%20u)%2C%202sin(6pi%20u)%2C%204u%20-%202))) — the checker bands stay parallel along the tube: the RMF absorbs torsion, so the material coordinate doesn't spiral

## Details

- `buildTube` now emits per-vertex UVs (arclength fraction, angle fraction) and picks checker cell counts: the angular cell is 2πr/8, the along-length count matches it for square-ish cells, rounded **even on closed curves** so parity continues across the loop seam (the RMF holonomy correction already makes the angle continuous there).
- Rings carry a duplicated seam column (angle 0 re-emitted as angle 1) so the UV interpolates cleanly across the wrap instead of sweeping backwards through the whole range in one quad.
- The fragment shader fades the checker to its average shade as cells approach pixel scale (`fwidth`), so thin or distant tubes don't moiré.
- Cell counts and arclength are computed on the CPU where the mesh is already built — the symbolic derivatives (via the RMF) are what make the non-twisting angular coordinate possible; no new differentiation was needed.

## Test plan

- `pnpm test` — 92 passing, including new cases: UVs linear in arclength on a constant-speed helix, seam column duplicates position with v=1, cell counts square-ish and even on closed loops
- `pnpm typecheck` — clean
- Verified in the browser in light and dark themes, at default and large radii

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Migrated from equation-src#25 as part of the open-source move.*
