### PR TITLE
Swipe to dismiss the equations panel on touch screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,12 @@ pnpm deploy     # build and deploy to Cloudflare
 
 Equations persist in the URL hash. Drag to pan/orbit, wheel to zoom,
 right-drag (or shift) to pan in 3D, click a color dot to cycle colors. Points
-and dropped ODE seeds highlight under the cursor and drag with it. On a touch
-screen, flick the equations panel up or off to the side to clear the view —
-it tracks the finger and leaves along the throw — and the `y=` chip left in
-its corner brings it back (tap it, or drag it to pull the panel in).
+and dropped ODE seeds highlight under the cursor and drag with it. The
+equations panel is a corner-pinned card: flick it — touch anywhere on it, or
+drag the grip strip along its top edge with a mouse — to send it to any
+corner, or throw it past any edge to clear the view entirely; it tracks the
+pointer and leaves along the throw. The `y=` chip left behind brings it back
+(tap it, or drag it to pull the panel in), and the chosen corner sticks.
 
 `worker/` — the Cloudflare Worker entry: serves the built app and handles
 `/api/*` routes.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,10 @@ pnpm deploy     # build and deploy to Cloudflare
 
 Equations persist in the URL hash. Drag to pan/orbit, wheel to zoom,
 right-drag (or shift) to pan in 3D, click a color dot to cycle colors. Points
-and dropped ODE seeds highlight under the cursor and drag with it.
+and dropped ODE seeds highlight under the cursor and drag with it. On a touch
+screen, flick the equations panel up or off to the side to clear the view —
+it tracks the finger and leaves along the throw — and the `y=` chip left in
+its corner brings it back (tap it, or drag it to pull the panel in).
 
 `worker/` — the Cloudflare Worker entry: serves the built app and handles
 `/api/*` routes.

--- a/lib/fling.test.ts
+++ b/lib/fling.test.ts
@@ -1,21 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CORNER_PROJECT_S,
   type Sample,
   type Vec2,
   claimGesture,
-  exitDistances,
-  exitTarget,
+  cornerPositions,
+  dismissEdge,
+  exitRay,
   makeSpring,
+  nearestCorner,
   project,
   releaseVelocity,
   rubberband,
-  shouldDismiss,
   shouldOpen,
   stepSpring,
+  throwDir,
 } from './fling.ts';
 
-/** A 300×500 panel sitting 12px in from the top-left corner. */
-const BOX = { left: 12, top: 12, width: 300, height: 500 };
+/** A 300×500 panel in a 390×720 phone viewport with 12px margins. */
+const W = 300;
+const H = 500;
+const VW = 390;
+const VH = 720;
+const M = { top: 12, right: 12, bottom: 12, left: 12 };
+const CORNERS = cornerPositions(VW, VH, W, H, M);
 
 describe('rubberband', () => {
   it('resists immediately and saturates at the limit', () => {
@@ -77,26 +85,112 @@ describe('releaseVelocity', () => {
   });
 });
 
-describe('shouldDismiss', () => {
-  it('dismisses a slow drag carried past half the panel', () => {
-    expect(shouldDismiss({ x: 0, y: -260 }, { x: 0, y: 0 }, BOX)).toBe(true);
-    expect(shouldDismiss({ x: -160, y: 0 }, { x: 0, y: 0 }, BOX)).toBe(true);
+describe('cornerPositions', () => {
+  it('rests the panel inside the margins at all four corners', () => {
+    expect(CORNERS).toEqual([
+      { x: 12, y: 12 },
+      { x: VW - 12 - W, y: 12 },
+      { x: 12, y: VH - 12 - H },
+      { x: VW - 12 - W, y: VH - 12 - H },
+    ]);
   });
 
-  it('cancels a slow drag short of half', () => {
-    expect(shouldDismiss({ x: 0, y: -240 }, { x: 0, y: 0 }, BOX)).toBe(false);
-    expect(shouldDismiss({ x: -140, y: 0 }, { x: 0, y: 0 }, BOX)).toBe(false);
+  it('honors asymmetric margins (safe areas)', () => {
+    const c = cornerPositions(VW, VH, W, H, { top: 60, right: 12, bottom: 40, left: 20 });
+    expect(c[0]).toEqual({ x: 20, y: 60 });
+    expect(c[3]).toEqual({ x: VW - 12 - W, y: VH - 40 - H });
+  });
+});
+
+describe('nearestCorner', () => {
+  it('picks the corner the projected point belongs to', () => {
+    expect(nearestCorner({ x: 0, y: 0 }, CORNERS)).toBe(0);
+    expect(nearestCorner({ x: VW, y: 0 }, CORNERS)).toBe(1);
+    expect(nearestCorner({ x: 0, y: VH }, CORNERS)).toBe(2);
+    expect(nearestCorner({ x: VW, y: VH }, CORNERS)).toBe(3);
   });
 
-  it('lets a flick dismiss from a short distance (projection covers the rest)', () => {
-    // 60px in, flicked up at 1600px/s: projects to 60 + 320 past halfway.
-    expect(shouldDismiss({ x: 0, y: -60 }, { x: 0, y: -1600 }, BOX)).toBe(true);
-    expect(shouldDismiss({ x: -40, y: 0 }, { x: -1400, y: 0 }, BOX)).toBe(true);
+  it('is decided by the projection, so a soft flick crosses the screen', () => {
+    // At TL, flicked down at 1500 px/s: the projected point, not the current
+    // one, must land in BL territory.
+    const pos = CORNERS[0];
+    const v = { x: 0, y: 1500 };
+    expect(nearestCorner(project(pos, v, CORNER_PROJECT_S), CORNERS)).toBe(2);
+    // The same flick judged at the current position would stay put.
+    expect(nearestCorner(pos, CORNERS)).toBe(0);
+  });
+});
+
+describe('dismissEdge', () => {
+  it('stays on-screen for positions inside the viewport', () => {
+    for (const c of CORNERS) expect(dismissEdge(c, W, H, VW, VH)).toBeNull();
+    expect(dismissEdge({ x: 45, y: 110 }, W, H, VW, VH)).toBeNull();
+  });
+
+  it('commits once more than half the panel projects past an edge', () => {
+    expect(dismissEdge({ x: -151, y: 12 }, W, H, VW, VH)).toBe('left');
+    expect(dismissEdge({ x: -149, y: 12 }, W, H, VW, VH)).toBeNull();
+    expect(dismissEdge({ x: 12, y: -251 }, W, H, VW, VH)).toBe('top');
+    expect(dismissEdge({ x: VW - W + 151, y: 12 }, W, H, VW, VH)).toBe('right');
+    expect(dismissEdge({ x: 12, y: VH - H + 251 }, W, H, VW, VH)).toBe('bottom');
+  });
+
+  it('lets a flick commit through the projection', () => {
+    // 60px into a drag toward the top, flicked at 1600 px/s.
+    const proj = project({ x: 12, y: -48 }, { x: 0, y: -1600 });
+    expect(dismissEdge(proj, W, H, VW, VH)).toBe('top');
   });
 
   it('lets a pull-back flick rescue a drag already past half', () => {
-    // Physically past halfway, but thrown back toward home on release.
-    expect(shouldDismiss({ x: 0, y: -270 }, { x: 0, y: 800 }, BOX)).toBe(false);
+    const proj = project({ x: 12, y: -260 }, { x: 0, y: 900 });
+    expect(dismissEdge(proj, W, H, VW, VH)).toBeNull();
+  });
+
+  it('reads a diagonal hurl as its deepest edge', () => {
+    // Past half on the left (fraction 160/300) and beyond on the top
+    // (fraction 300/500): top is the deeper crossing.
+    expect(dismissEdge({ x: -160, y: -300 }, W, H, VW, VH)).toBe('top');
+  });
+});
+
+describe('throwDir', () => {
+  const edge = 'left' as const;
+
+  it('follows the throw when there is one', () => {
+    expect(throwDir({ x: -900, y: -200 }, { x: -10, y: 0 }, edge)).toEqual({ x: -900, y: -200 });
+  });
+
+  it('keeps a slow carry’s heading', () => {
+    expect(throwDir({ x: -40, y: 0 }, { x: -180, y: -30 }, edge)).toEqual({ x: -180, y: -30 });
+  });
+
+  it('falls back to straight out the crossed edge', () => {
+    expect(throwDir({ x: 0, y: 0 }, { x: 0, y: 0 }, 'bottom')).toEqual({ x: 0, y: 1 });
+  });
+});
+
+describe('exitRay', () => {
+  it('continues along the throw until one side fully clears', () => {
+    // From TL thrown hard left with a slight upward drift.
+    const t = exitRay({ x: -80, y: 0 }, { x: -1200, y: -100 }, W, H, VW, VH);
+    expect(t.x).toBeCloseTo(-W - 28, 5);
+    expect(t.y).toBeCloseTo(-((-W - 28 + 80) / -1200) * 100, 5);
+  });
+
+  it('can leave past any corner on a diagonal throw', () => {
+    // From BR, thrown down-right: exits whichever side the ray meets first.
+    const pos = CORNERS[3];
+    const t = exitRay(pos, { x: 900, y: 900 }, W, H, VW, VH);
+    const clearsRight = t.x >= VW + 28 - 1e-6;
+    const clearsBottom = t.y >= VH + 28 - 1e-6;
+    expect(clearsRight || clearsBottom).toBe(true);
+    // And it kept the 45° heading.
+    expect(t.x - pos.x).toBeCloseTo(t.y - pos.y, 5);
+  });
+
+  it('leaves a panel already fully out where it is', () => {
+    const out = { x: -W - 100, y: 12 };
+    expect(exitRay(out, { x: -500, y: 0 }, W, H, VW, VH)).toEqual(out);
   });
 });
 
@@ -115,48 +209,13 @@ describe('shouldOpen', () => {
     expect(shouldOpen({ x: -160, y: -120 }, { x: 0, y: 0 }, diag)).toBe(true);
     expect(shouldOpen({ x: -360, y: -270 }, { x: 0, y: 0 }, diag)).toBe(false);
   });
-});
 
-describe('exitTarget', () => {
-  const dists = exitDistances(BOX); // {x: 340, y: 540}
-
-  it('computes exit travel from the panel box', () => {
-    expect(dists).toEqual({ x: 12 + 300 + 28, y: 12 + 500 + 28 });
-  });
-
-  it('continues along the throw line until one axis clears the screen', () => {
-    const t = exitTarget({ x: -80, y: -10 }, { x: -1200, y: -100 }, dists);
-    // Leftward is the near exit: x lands exactly fully off-screen.
-    expect(t.x).toBeCloseTo(-340, 5);
-    // y keeps the throw's slope: 100/1200 of the remaining 260px of x travel.
-    expect(t.y).toBeCloseTo(-10 - (260 / 1200) * 100, 5);
-  });
-
-  it('falls back to the drag displacement on a slow release', () => {
-    const t = exitTarget({ x: -180, y: -6 }, { x: -40, y: 0 }, dists);
-    expect(t.x).toBeCloseTo(-340, 5);
-    expect(t.y).toBeCloseTo(-6 - (160 / 180) * 6, 5);
-  });
-
-  it('drops throw components that point back on-screen', () => {
-    // Thrown up and to the right: exits straight up, x pinned where it is.
-    const t = exitTarget({ x: -30, y: -100 }, { x: 600, y: -900 }, dists);
-    expect(t.x).toBe(-30);
-    expect(t.y).toBeCloseTo(-540, 5);
-  });
-
-  it('uses the displacement when the whole throw points on-screen', () => {
-    // Deep left drag released with a small down-right jitter above the speed
-    // floor: the exit must still leave leftward, not "straight up".
-    const t = exitTarget({ x: -260, y: 0 }, { x: 200, y: 260 }, dists);
-    expect(t.x).toBeCloseTo(-340, 5);
-    expect(t.y).toBe(0);
-  });
-
-  it('goes straight up given nothing to go on', () => {
-    const t = exitTarget({ x: 0, y: 0 }, { x: 0, y: 0 }, dists);
-    expect(t.x).toBe(0);
-    expect(t.y).toBeCloseTo(-540, 5);
+  it('works for parks past the far edges too', () => {
+    // Pinned bottom-right, thrown off to the right: parked is positive-x.
+    const parkedRight: Vec2 = { x: 340, y: 0 };
+    expect(shouldOpen({ x: 120, y: 0 }, { x: 0, y: 0 }, parkedRight)).toBe(true);
+    expect(shouldOpen({ x: 220, y: 0 }, { x: 0, y: 0 }, parkedRight)).toBe(false);
+    expect(shouldOpen({ x: 320, y: 0 }, { x: -1200, y: 0 }, parkedRight)).toBe(true);
   });
 });
 

--- a/lib/fling.test.ts
+++ b/lib/fling.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type Sample,
+  type Vec2,
+  claimGesture,
+  exitDistances,
+  exitTarget,
+  makeSpring,
+  project,
+  releaseVelocity,
+  rubberband,
+  shouldDismiss,
+  shouldOpen,
+  stepSpring,
+} from './fling.ts';
+
+/** A 300×500 panel sitting 12px in from the top-left corner. */
+const BOX = { left: 12, top: 12, width: 300, height: 500 };
+
+describe('rubberband', () => {
+  it('resists immediately and saturates at the limit', () => {
+    expect(rubberband(0)).toBe(0);
+    expect(rubberband(10)).toBeLessThan(10);
+    expect(rubberband(10)).toBeGreaterThan(0);
+    expect(rubberband(1e6)).toBeLessThan(90);
+    expect(rubberband(1e6)).toBeGreaterThan(85);
+  });
+
+  it('is monotonic (more pull always shows more give)', () => {
+    let prev = 0;
+    for (let d = 10; d <= 500; d += 10) {
+      const f = rubberband(d);
+      expect(f).toBeGreaterThan(prev);
+      prev = f;
+    }
+  });
+
+  it('passes free directions through as zero', () => {
+    expect(rubberband(-40)).toBe(0);
+  });
+});
+
+describe('releaseVelocity', () => {
+  const line = (n: number, dtMs: number, step: Vec2): Sample[] =>
+    Array.from({ length: n }, (_, i) => ({ t: i * dtMs, x: i * step.x, y: i * step.y }));
+
+  it('measures a steady drag', () => {
+    // 10px per 16ms upward: 625 px/s.
+    const v = releaseVelocity(line(10, 16, { x: 0, y: -10 }), 9 * 16);
+    expect(v.x).toBe(0);
+    expect(v.y).toBeCloseTo(-625, 0);
+  });
+
+  it('only reads the recent window, not the whole gesture', () => {
+    // A slow start followed by a fast finish must report the finish.
+    const samples: Sample[] = [
+      { t: 0, x: 0, y: 0 },
+      { t: 300, x: 0, y: -10 }, // crawl
+      { t: 340, x: 0, y: -50 },
+      { t: 380, x: 0, y: -90 }, // 1000 px/s
+    ];
+    const v = releaseVelocity(samples, 380);
+    expect(v.y).toBeCloseTo(-1000, 0);
+  });
+
+  it('reports zero after the finger rests before lifting', () => {
+    // Drag, hold still (no samples arrive while stationary), then release:
+    // the old motion must not replay as a throw.
+    const samples = line(10, 16, { x: 0, y: -10 });
+    const v = releaseVelocity(samples, 9 * 16 + 400);
+    expect(v).toEqual({ x: 0, y: 0 });
+  });
+
+  it('handles empty and single-sample gestures', () => {
+    expect(releaseVelocity([], 0)).toEqual({ x: 0, y: 0 });
+    expect(releaseVelocity([{ t: 5, x: 1, y: 1 }], 10)).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('shouldDismiss', () => {
+  it('dismisses a slow drag carried past half the panel', () => {
+    expect(shouldDismiss({ x: 0, y: -260 }, { x: 0, y: 0 }, BOX)).toBe(true);
+    expect(shouldDismiss({ x: -160, y: 0 }, { x: 0, y: 0 }, BOX)).toBe(true);
+  });
+
+  it('cancels a slow drag short of half', () => {
+    expect(shouldDismiss({ x: 0, y: -240 }, { x: 0, y: 0 }, BOX)).toBe(false);
+    expect(shouldDismiss({ x: -140, y: 0 }, { x: 0, y: 0 }, BOX)).toBe(false);
+  });
+
+  it('lets a flick dismiss from a short distance (projection covers the rest)', () => {
+    // 60px in, flicked up at 1600px/s: projects to 60 + 320 past halfway.
+    expect(shouldDismiss({ x: 0, y: -60 }, { x: 0, y: -1600 }, BOX)).toBe(true);
+    expect(shouldDismiss({ x: -40, y: 0 }, { x: -1400, y: 0 }, BOX)).toBe(true);
+  });
+
+  it('lets a pull-back flick rescue a drag already past half', () => {
+    // Physically past halfway, but thrown back toward home on release.
+    expect(shouldDismiss({ x: 0, y: -270 }, { x: 0, y: 800 }, BOX)).toBe(false);
+  });
+});
+
+describe('shouldOpen', () => {
+  const parked: Vec2 = { x: 0, y: -540 };
+
+  it('opens once pulled (or projected) past halfway home', () => {
+    expect(shouldOpen({ x: 0, y: -260 }, { x: 0, y: 0 }, parked)).toBe(true);
+    expect(shouldOpen({ x: 0, y: -300 }, { x: 0, y: 0 }, parked)).toBe(false);
+    // A flick toward home from barely off the parked spot.
+    expect(shouldOpen({ x: 0, y: -480 }, { x: 0, y: 1400 }, parked)).toBe(true);
+  });
+
+  it('measures along the parked ray for diagonal parks', () => {
+    const diag: Vec2 = { x: -400, y: -300 };
+    expect(shouldOpen({ x: -160, y: -120 }, { x: 0, y: 0 }, diag)).toBe(true);
+    expect(shouldOpen({ x: -360, y: -270 }, { x: 0, y: 0 }, diag)).toBe(false);
+  });
+});
+
+describe('exitTarget', () => {
+  const dists = exitDistances(BOX); // {x: 340, y: 540}
+
+  it('computes exit travel from the panel box', () => {
+    expect(dists).toEqual({ x: 12 + 300 + 28, y: 12 + 500 + 28 });
+  });
+
+  it('continues along the throw line until one axis clears the screen', () => {
+    const t = exitTarget({ x: -80, y: -10 }, { x: -1200, y: -100 }, dists);
+    // Leftward is the near exit: x lands exactly fully off-screen.
+    expect(t.x).toBeCloseTo(-340, 5);
+    // y keeps the throw's slope: 100/1200 of the remaining 260px of x travel.
+    expect(t.y).toBeCloseTo(-10 - (260 / 1200) * 100, 5);
+  });
+
+  it('falls back to the drag displacement on a slow release', () => {
+    const t = exitTarget({ x: -180, y: -6 }, { x: -40, y: 0 }, dists);
+    expect(t.x).toBeCloseTo(-340, 5);
+    expect(t.y).toBeCloseTo(-6 - (160 / 180) * 6, 5);
+  });
+
+  it('drops throw components that point back on-screen', () => {
+    // Thrown up and to the right: exits straight up, x pinned where it is.
+    const t = exitTarget({ x: -30, y: -100 }, { x: 600, y: -900 }, dists);
+    expect(t.x).toBe(-30);
+    expect(t.y).toBeCloseTo(-540, 5);
+  });
+
+  it('uses the displacement when the whole throw points on-screen', () => {
+    // Deep left drag released with a small down-right jitter above the speed
+    // floor: the exit must still leave leftward, not "straight up".
+    const t = exitTarget({ x: -260, y: 0 }, { x: 200, y: 260 }, dists);
+    expect(t.x).toBeCloseTo(-340, 5);
+    expect(t.y).toBe(0);
+  });
+
+  it('goes straight up given nothing to go on', () => {
+    const t = exitTarget({ x: 0, y: 0 }, { x: 0, y: 0 }, dists);
+    expect(t.x).toBe(0);
+    expect(t.y).toBeCloseTo(-540, 5);
+  });
+});
+
+describe('spring', () => {
+  /** Run a spring to rest (or the step cap) and record its path. */
+  const run = (s: ReturnType<typeof makeSpring>, dt = 1 / 60) => {
+    const path: number[] = [];
+    for (let i = 0; i < 600 && stepSpring(s, dt); i++) path.push(s.x);
+    return path;
+  };
+
+  it('settles exactly on the target', () => {
+    const s = makeSpring(0, 0, -340, 0.32, 1);
+    run(s);
+    expect(s.x).toBe(-340);
+    expect(s.v).toBe(0);
+  });
+
+  it('does not overshoot at critical damping', () => {
+    const s = makeSpring(-40, 0, -340, 0.32, 1);
+    for (const x of run(s)) expect(x).toBeGreaterThanOrEqual(-340.5);
+  });
+
+  it('overshoots and returns below critical damping', () => {
+    const s = makeSpring(-200, 0, 0, 0.4, 0.78);
+    const path = run(s);
+    expect(Math.max(...path)).toBeGreaterThan(0); // one visible bounce…
+    expect(Math.max(...path)).toBeLessThan(30); // …but a small one
+    expect(s.x).toBe(0);
+  });
+
+  it('carries the hand-off velocity through the release', () => {
+    // Released moving away from the target: a spring that took the velocity
+    // keeps moving away briefly before turning — the finger's motion is not
+    // discarded at release.
+    const s = makeSpring(-100, -500, 0, 0.4, 0.78);
+    stepSpring(s, 1 / 60);
+    expect(s.x).toBeLessThan(-100);
+    run(s);
+    expect(s.x).toBe(0);
+  });
+
+  it('survives a stalled tab (huge dt) without exploding', () => {
+    const s = makeSpring(-200, 3000, 0, 0.32, 1);
+    stepSpring(s, 5); // a 5s frame gap is clamped, not integrated in one step
+    expect(Number.isFinite(s.x)).toBe(true);
+    expect(Math.abs(s.x)).toBeLessThan(1000);
+  });
+});
+
+describe('claimGesture', () => {
+  const scrollBoth = { up: true, down: true };
+  const atBottom = { up: true, down: false };
+  const atTop = { up: false, down: true };
+
+  it('stays undecided inside the slop circle', () => {
+    expect(claimGesture(4, -4, null)).toBe('undecided');
+    expect(claimGesture(0, -8, scrollBoth)).toBe('undecided');
+  });
+
+  it('claims horizontal motion for the panel (nothing scrolls sideways)', () => {
+    expect(claimGesture(-24, -10, scrollBoth)).toBe('panel');
+    expect(claimGesture(24, 10, scrollBoth)).toBe('panel');
+  });
+
+  it('cedes vertical motion the list can consume', () => {
+    expect(claimGesture(2, -20, atTop)).toBe('scroll'); // finger up, list has more below
+    expect(claimGesture(2, 20, atBottom)).toBe('scroll'); // finger down, list has more above
+  });
+
+  it('claims vertical motion at the list edge (the sheet behavior)', () => {
+    expect(claimGesture(2, -20, atBottom)).toBe('panel');
+    expect(claimGesture(2, 20, atTop)).toBe('panel');
+    expect(claimGesture(0, -20, null)).toBe('panel'); // nothing scrollable at all
+  });
+});
+
+describe('project', () => {
+  it('adds the deceleration horizon to the offset', () => {
+    expect(project({ x: -10, y: -20 }, { x: -100, y: 200 })).toEqual({ x: -30, y: 20 });
+  });
+});

--- a/lib/fling.ts
+++ b/lib/fling.ts
@@ -1,20 +1,24 @@
 /**
- * Touch-dismissal physics: the math behind flicking a panel off-screen the
- * way iOS moves its sheets and banners. Pure and DOM-free — web/panel-swipe.ts
- * owns the touch events and styles — so the tuning that makes the gesture
- * feel right lives under test.
+ * Touch-dismissal and corner-pinning physics: the math behind flicking a
+ * panel between screen corners or off-screen entirely, the way iOS moves its
+ * sheets, banners, and picture-in-picture window. Pure and DOM-free —
+ * web/panel-swipe.ts owns the events and styles — so the tuning that makes
+ * the gesture feel right lives under test.
  *
  * The feel comes from four rules borrowed from UIKit:
  *  - while touched, the panel is pinned to the finger — no easing, no lag;
- *  - directions that cannot dismiss resist with a diminishing-returns rubber
- *    band instead of a hard stop;
  *  - release decides by *projected momentum* (where the panel would coast to,
- *    not where it is), so a slow drag past halfway and a short sharp flick
- *    both dismiss;
+ *    not where it is), so a slow drag past halfway off an edge and a short
+ *    sharp flick both dismiss, and a soft directional flick is enough to send
+ *    the panel across the screen to another corner;
+ *  - the projected point picks the destination: past half the panel beyond
+ *    any screen edge it leaves along the throw line, otherwise it belongs to
+ *    the nearest corner — Apple's picture-in-picture recipe;
  *  - the hand-off from finger to animation is a spring seeded with the
  *    release velocity, so motion stays continuous through the release.
  *
- * Units are px and seconds throughout (sample times in ms, as events give).
+ * Coordinates are the panel's top-left corner in viewport space, px and
+ * seconds throughout (sample times in ms, as events give).
  */
 
 export interface Vec2 {
@@ -31,10 +35,12 @@ export interface Sample {
 }
 
 /**
- * Diminishing-returns pull for directions that cannot dismiss, UIScrollView's
- * overscroll curve: starts at slope `c` and approaches `limit` asymptotically,
- * so the panel visibly gives but can never be dragged far the wrong way.
- * Negative input (a direction that is free, not resisted) passes through 0.
+ * Diminishing-returns pull, UIScrollView's overscroll curve: starts at slope
+ * `c` and approaches `limit` asymptotically, so pulling the panel past a
+ * boundary visibly gives but never gets far. Used when pulling the panel
+ * open beyond its parked and home positions; ordinary panel drags are free
+ * in every direction (every direction leads somewhere). Negative input (a
+ * free direction) passes through 0.
  */
 export function rubberband(d: number, limit = 90, c = 0.55): number {
   if (d <= 0) return 0;
@@ -65,80 +71,126 @@ export function releaseVelocity(samples: readonly Sample[], t: number): Vec2 {
   return { x: (last.x - first.x) / dt, y: (last.y - first.y) / dt };
 }
 
-/** How far ahead a release looks: ~the distance a friction-decayed coast
- *  would add. Larger reads more flick-sensitive. */
+/** How far ahead the *dismissal* test looks: ~the distance a friction-decayed
+ *  coast would add. Kept short so leaving the screen takes real intent. */
 const PROJECT_S = 0.2;
+
+/** How far ahead the *corner* pick looks. Longer than the dismissal horizon:
+ *  crossing the screen should take a soft directional flick, not a hurl —
+ *  the panel glides the distance the finger implied. */
+export const CORNER_PROJECT_S = 0.35;
 
 /** Where the gesture would coast to if the finger's momentum carried on. */
 export function project(offset: Vec2, v: Vec2, tau = PROJECT_S): Vec2 {
   return { x: offset.x + v.x * tau, y: offset.y + v.y * tau };
 }
 
-/** The panel's at-rest viewport box, as the DOM side measures it. */
-export interface Box {
-  left: number;
+/** Clear margins the panel rests inside (screen edge + safe areas). */
+export interface Margins {
   top: number;
-  width: number;
-  height: number;
+  right: number;
+  bottom: number;
+  left: number;
 }
 
 /**
- * Travel needed per axis (as a positive number) before a panel anchored at
- * the top-left has fully cleared the screen; `pad` covers its drop shadow.
+ * The four rest positions of a w×h panel — TL, TR, BL, BR — as top-left
+ * coordinates inside a vw×vh viewport.
  */
-export function exitDistances(box: Box, pad = 28): Vec2 {
-  return { x: box.left + box.width + pad, y: box.top + box.height + pad };
+export function cornerPositions(vw: number, vh: number, w: number, h: number, m: Margins): Vec2[] {
+  return [
+    { x: m.left, y: m.top },
+    { x: vw - m.right - w, y: m.top },
+    { x: m.left, y: vh - m.bottom - h },
+    { x: vw - m.right - w, y: vh - m.bottom - h },
+  ];
 }
 
-/**
- * Commit or cancel: dismiss when the projected point has crossed half the
- * panel on either dismissing axis (up or left). Encodes both ways out — a
- * slow deliberate drag past halfway with no speed, and a flick whose
- * projection covers the distance the finger didn't.
- */
-export function shouldDismiss(offset: Vec2, v: Vec2, box: Box): boolean {
-  const p = project(offset, v);
-  return -p.x > box.width / 2 || -p.y > box.height / 2;
+/** Index of the corner nearest to `p` — fed the *projected* release point,
+ *  this is Apple's fluid-interfaces corner-pinning rule. */
+export function nearestCorner(p: Vec2, corners: readonly Vec2[]): number {
+  let best = 0;
+  let bestD = Infinity;
+  corners.forEach((c, i) => {
+    const d = (c.x - p.x) ** 2 + (c.y - p.y) ** 2;
+    if (d < bestD) {
+      bestD = d;
+      best = i;
+    }
+  });
+  return best;
 }
 
+export type Edge = 'left' | 'right' | 'top' | 'bottom';
+
 /**
- * Whether releasing a pull-open drag (from the collapsed chip) should open
- * the panel: the projected point must be more than halfway home along the
- * ray it was parked on. The mirror of shouldDismiss.
+ * Commit or stay: the edge the projected position has pushed more than half
+ * the panel beyond — the dismissal decision — or null to remain on-screen.
+ * All four edges count, so the panel can be thrown out past any corner. Ties
+ * go to the deepest overhang, so a diagonal hurl reads as the edge it most
+ * clearly crossed.
  */
-export function shouldOpen(offset: Vec2, v: Vec2, parked: Vec2): boolean {
-  const p = project(offset, v);
-  const len2 = parked.x * parked.x + parked.y * parked.y;
-  if (!len2) return true;
-  return (p.x * parked.x + p.y * parked.y) / len2 < 0.5;
+export function dismissEdge(proj: Vec2, w: number, h: number, vw: number, vh: number): Edge | null {
+  // Each entry: how far the panel pokes past that edge, and the size of the
+  // panel on that axis (the yardstick for "half").
+  const overhangs: Array<[Edge, number, number]> = [
+    ['left', -proj.x, w],
+    ['right', proj.x + w - vw, w],
+    ['top', -proj.y, h],
+    ['bottom', proj.y + h - vh, h],
+  ];
+  let best: Edge | null = null;
+  let bestFrac = 0.5; // more than half the panel must be projected out
+  for (const [edge, over, size] of overhangs) {
+    const frac = over / size;
+    if (frac > bestFrac) {
+      bestFrac = frac;
+      best = edge;
+    }
+  }
+  return best;
 }
 
 /** Slower than this (px/s) a release has no direction of its own. */
 const THROW_MIN_SPEED = 250;
 
 /**
- * Where a dismissal flies to: continue along the release velocity — the panel
- * leaves on the line it was thrown, like a flicked photo — stopping as soon
- * as one axis has fully cleared the screen. A slow release reuses the drag
- * displacement as its direction instead. Components pointing back on-screen
- * (down, right) are dropped: nothing exits that way.
+ * The direction a dismissal leaves in: the throw velocity when there is one,
+ * else the drag displacement (a slow carry keeps its heading), else straight
+ * out the crossed edge.
  */
-export function exitTarget(offset: Vec2, v: Vec2, dists: Vec2, minSpeed = THROW_MIN_SPEED): Vec2 {
-  const fast = Math.hypot(v.x, v.y) >= minSpeed;
-  let dx = fast ? Math.min(v.x, 0) : 0;
-  let dy = fast ? Math.min(v.y, 0) : 0;
-  if (!dx && !dy) {
-    // Slow release, or a throw pointing entirely back on-screen: leave along
-    // the drag displacement instead.
-    dx = Math.min(offset.x, 0);
-    dy = Math.min(offset.y, 0);
-  }
-  if (!dx && !dy) dy = -1; // nothing to go on at all: straight up
-  const s = Math.min(
-    dx < 0 ? (-dists.x - offset.x) / dx : Infinity,
-    dy < 0 ? (-dists.y - offset.y) / dy : Infinity,
-  );
-  return { x: offset.x + dx * s, y: offset.y + dy * s };
+export function throwDir(v: Vec2, disp: Vec2, edge: Edge, minSpeed = THROW_MIN_SPEED): Vec2 {
+  if (Math.hypot(v.x, v.y) >= minSpeed) return v;
+  if (Math.hypot(disp.x, disp.y) > 1) return disp;
+  return { left: { x: -1, y: 0 }, right: { x: 1, y: 0 }, top: { x: 0, y: -1 }, bottom: { x: 0, y: 1 } }[edge];
+}
+
+/**
+ * Where a dismissal flies to: from `pos` along `dir` until the panel has
+ * fully cleared the viewport on whichever side the ray reaches first (`pad`
+ * covers the drop shadow). A panel already fully out stays where it is.
+ */
+export function exitRay(pos: Vec2, dir: Vec2, w: number, h: number, vw: number, vh: number, pad = 28): Vec2 {
+  let t = Infinity;
+  if (dir.x < 0) t = Math.min(t, (-w - pad - pos.x) / dir.x);
+  if (dir.x > 0) t = Math.min(t, (vw + pad - pos.x) / dir.x);
+  if (dir.y < 0) t = Math.min(t, (-h - pad - pos.y) / dir.y);
+  if (dir.y > 0) t = Math.min(t, (vh + pad - pos.y) / dir.y);
+  if (!isFinite(t) || t <= 0) return pos;
+  return { x: pos.x + dir.x * t, y: pos.y + dir.y * t };
+}
+
+/**
+ * Whether releasing a pull-open drag (from the collapsed chip) should open
+ * the panel: the projected point must be more than halfway home along the
+ * ray it was parked on, `parked` and `offset` both relative to the pinned
+ * corner's rest position. The mirror of dismissEdge.
+ */
+export function shouldOpen(offset: Vec2, v: Vec2, parked: Vec2): boolean {
+  const p = project(offset, v);
+  const len2 = parked.x * parked.x + parked.y * parked.y;
+  if (!len2) return true;
+  return (p.x * parked.x + p.y * parked.y) / len2 < 0.5;
 }
 
 /**

--- a/lib/fling.ts
+++ b/lib/fling.ts
@@ -1,0 +1,212 @@
+/**
+ * Touch-dismissal physics: the math behind flicking a panel off-screen the
+ * way iOS moves its sheets and banners. Pure and DOM-free — web/panel-swipe.ts
+ * owns the touch events and styles — so the tuning that makes the gesture
+ * feel right lives under test.
+ *
+ * The feel comes from four rules borrowed from UIKit:
+ *  - while touched, the panel is pinned to the finger — no easing, no lag;
+ *  - directions that cannot dismiss resist with a diminishing-returns rubber
+ *    band instead of a hard stop;
+ *  - release decides by *projected momentum* (where the panel would coast to,
+ *    not where it is), so a slow drag past halfway and a short sharp flick
+ *    both dismiss;
+ *  - the hand-off from finger to animation is a spring seeded with the
+ *    release velocity, so motion stays continuous through the release.
+ *
+ * Units are px and seconds throughout (sample times in ms, as events give).
+ */
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+/** A touch position at a moment, straight from a touchmove. */
+export interface Sample {
+  /** Event timeStamp, ms. */
+  t: number;
+  x: number;
+  y: number;
+}
+
+/**
+ * Diminishing-returns pull for directions that cannot dismiss, UIScrollView's
+ * overscroll curve: starts at slope `c` and approaches `limit` asymptotically,
+ * so the panel visibly gives but can never be dragged far the wrong way.
+ * Negative input (a direction that is free, not resisted) passes through 0.
+ */
+export function rubberband(d: number, limit = 90, c = 0.55): number {
+  if (d <= 0) return 0;
+  return (1 - 1 / ((c * d) / limit + 1)) * limit;
+}
+
+/** Samples older than this before the release no longer describe the throw. */
+const V_WINDOW_MS = 100;
+/** A finger that rested this long before lifting released at velocity zero. */
+const V_STALL_MS = 80;
+
+/**
+ * Release velocity (px/s) over the last V_WINDOW_MS of a gesture, the way
+ * UIPanGestureRecognizer reports it. `t` is the release time: touchmove stops
+ * firing the moment the finger stops, so without the stall gate a
+ * drag-pause-release would replay the stale pre-pause velocity as a throw.
+ */
+export function releaseVelocity(samples: readonly Sample[], t: number): Vec2 {
+  const last = samples[samples.length - 1];
+  if (!last || t - last.t > V_STALL_MS) return { x: 0, y: 0 };
+  let first = last;
+  for (let i = samples.length - 1; i >= 0; i--) {
+    if (last.t - samples[i].t > V_WINDOW_MS) break;
+    first = samples[i];
+  }
+  const dt = (last.t - first.t) / 1000;
+  if (dt <= 0) return { x: 0, y: 0 };
+  return { x: (last.x - first.x) / dt, y: (last.y - first.y) / dt };
+}
+
+/** How far ahead a release looks: ~the distance a friction-decayed coast
+ *  would add. Larger reads more flick-sensitive. */
+const PROJECT_S = 0.2;
+
+/** Where the gesture would coast to if the finger's momentum carried on. */
+export function project(offset: Vec2, v: Vec2, tau = PROJECT_S): Vec2 {
+  return { x: offset.x + v.x * tau, y: offset.y + v.y * tau };
+}
+
+/** The panel's at-rest viewport box, as the DOM side measures it. */
+export interface Box {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Travel needed per axis (as a positive number) before a panel anchored at
+ * the top-left has fully cleared the screen; `pad` covers its drop shadow.
+ */
+export function exitDistances(box: Box, pad = 28): Vec2 {
+  return { x: box.left + box.width + pad, y: box.top + box.height + pad };
+}
+
+/**
+ * Commit or cancel: dismiss when the projected point has crossed half the
+ * panel on either dismissing axis (up or left). Encodes both ways out — a
+ * slow deliberate drag past halfway with no speed, and a flick whose
+ * projection covers the distance the finger didn't.
+ */
+export function shouldDismiss(offset: Vec2, v: Vec2, box: Box): boolean {
+  const p = project(offset, v);
+  return -p.x > box.width / 2 || -p.y > box.height / 2;
+}
+
+/**
+ * Whether releasing a pull-open drag (from the collapsed chip) should open
+ * the panel: the projected point must be more than halfway home along the
+ * ray it was parked on. The mirror of shouldDismiss.
+ */
+export function shouldOpen(offset: Vec2, v: Vec2, parked: Vec2): boolean {
+  const p = project(offset, v);
+  const len2 = parked.x * parked.x + parked.y * parked.y;
+  if (!len2) return true;
+  return (p.x * parked.x + p.y * parked.y) / len2 < 0.5;
+}
+
+/** Slower than this (px/s) a release has no direction of its own. */
+const THROW_MIN_SPEED = 250;
+
+/**
+ * Where a dismissal flies to: continue along the release velocity — the panel
+ * leaves on the line it was thrown, like a flicked photo — stopping as soon
+ * as one axis has fully cleared the screen. A slow release reuses the drag
+ * displacement as its direction instead. Components pointing back on-screen
+ * (down, right) are dropped: nothing exits that way.
+ */
+export function exitTarget(offset: Vec2, v: Vec2, dists: Vec2, minSpeed = THROW_MIN_SPEED): Vec2 {
+  const fast = Math.hypot(v.x, v.y) >= minSpeed;
+  let dx = fast ? Math.min(v.x, 0) : 0;
+  let dy = fast ? Math.min(v.y, 0) : 0;
+  if (!dx && !dy) {
+    // Slow release, or a throw pointing entirely back on-screen: leave along
+    // the drag displacement instead.
+    dx = Math.min(offset.x, 0);
+    dy = Math.min(offset.y, 0);
+  }
+  if (!dx && !dy) dy = -1; // nothing to go on at all: straight up
+  const s = Math.min(
+    dx < 0 ? (-dists.x - offset.x) / dx : Infinity,
+    dy < 0 ? (-dists.y - offset.y) / dy : Infinity,
+  );
+  return { x: offset.x + dx * s, y: offset.y + dy * s };
+}
+
+/**
+ * A damped spring, in SwiftUI's parametrization: `response` is the undamped
+ * period in seconds (smaller = snappier) and `dampingRatio` 1 is critical —
+ * no overshoot — with values below 1 bouncing. Mass is 1. Springs rather
+ * than duration curves because they take an initial velocity, which is the
+ * whole trick of a gesture-driven animation: the panel keeps the speed the
+ * finger gave it.
+ */
+export interface Spring {
+  /** Current position (px) and velocity (px/s). */
+  x: number;
+  v: number;
+  target: number;
+  /** Stiffness ω² and damping 2ζω, from makeSpring. */
+  k: number;
+  c: number;
+}
+
+export function makeSpring(x: number, v: number, target: number, response: number, dampingRatio: number): Spring {
+  const w = (2 * Math.PI) / response;
+  return { x, v, target, k: w * w, c: 2 * dampingRatio * w };
+}
+
+/**
+ * Advance a spring by `dt` seconds (semi-implicit Euler, subdivided so a
+ * dropped frame cannot blow the integration up; a background-tab stall is
+ * clamped rather than fast-forwarded). Returns false once at rest, with the
+ * position snapped to the target. `restDist`/`restSpeed` are the rest
+ * thresholds — loose for a flight whose end is off-screen, tight for a
+ * settle the eye watches land.
+ */
+export function stepSpring(s: Spring, dt: number, restDist = 0.5, restSpeed = 20): boolean {
+  let remaining = Math.min(dt, 0.1);
+  while (remaining > 0) {
+    const h = Math.min(remaining, 1 / 120);
+    remaining -= h;
+    s.v += (-s.k * (s.x - s.target) - s.c * s.v) * h;
+    s.x += s.v * h;
+  }
+  if (Math.abs(s.x - s.target) < restDist && Math.abs(s.v) < restSpeed) {
+    s.x = s.target;
+    s.v = 0;
+    return false;
+  }
+  return true;
+}
+
+export type Claim = 'panel' | 'scroll' | 'undecided';
+
+/**
+ * Who owns a touch that has moved (dx, dy) from where it started: undecided
+ * inside the slop circle; the panel once motion is mostly horizontal (nothing
+ * inside the panel scrolls sideways); and for vertical motion, the scrollable
+ * under the finger wins whenever it could actually consume the move — the
+ * panel only drags once the list has nothing left to scroll that way, exactly
+ * how a sheet behaves under a scroll view on iOS. `scroll` says whether such
+ * a scrollable exists and which ways it can currently move.
+ */
+export function claimGesture(
+  dx: number,
+  dy: number,
+  scroll: { up: boolean; down: boolean } | null,
+  slop = 9,
+): Claim {
+  if (dx * dx + dy * dy < slop * slop) return 'undecided';
+  if (Math.abs(dx) > Math.abs(dy)) return 'panel';
+  // A finger moving up reveals content further down, and vice versa.
+  return (dy < 0 ? scroll?.down : scroll?.up) ? 'scroll' : 'panel';
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "deploy": "wrangler types && vite build && wrangler deploy",
     "typecheck": "wrangler types && tsc --noEmit && tsc -p web --noEmit && tsc -p worker --noEmit",
     "test:editor": "node scripts/editor-test.ts",
+    "test:swipe": "node scripts/swipe-test.ts",
     "bench": "vitest bench --run",
     "perf": "node scripts/perf.ts",
     "perf:update": "node scripts/perf.ts --update"

--- a/scripts/editor-test.ts
+++ b/scripts/editor-test.ts
@@ -79,7 +79,11 @@ for (let i = 0; ; i++) {
   await new Promise(r => setTimeout(r, 200));
 }
 
-const browser = await chromium.launch({ args: ['--enable-unsafe-swiftshader'] });
+// CHROMIUM overrides the browser binary, for containers with a system build.
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM || undefined,
+  args: ['--enable-unsafe-swiftshader'],
+});
 const page = await browser.newPage({ viewport: { width: 1000, height: 700 } });
 
 // --- events originating in slider widgets must not edit the document ---

--- a/scripts/swipe-test.ts
+++ b/scripts/swipe-test.ts
@@ -1,11 +1,14 @@
 /**
- * Browser tests for the panel swipe-to-dismiss gesture: `pnpm test:swipe`.
+ * Browser tests for the panel fling gesture: `pnpm test:swipe`.
  *
- * The gesture code (web/panel-swipe.ts) is arbitration between native touch
- * behaviors — scrolling, taps, clicks — and a custom drag, so unit tests of
- * the physics (lib/fling.test.ts) cannot cover it. This drives the real app
- * in headless Chromium with CDP-synthesized *trusted* touch input: real hit
- * testing, real scrolling, real click suppression after a swipe.
+ * The gesture code (web/panel-swipe.ts) is arbitration between native
+ * behaviors — scrolling, text selection, taps, clicks — and a custom drag,
+ * so unit tests of the physics (lib/fling.test.ts) cannot cover it. This
+ * drives the real app in headless Chromium with CDP-synthesized *trusted*
+ * input: real hit testing, real scrolling, real focus, real click
+ * suppression after a swipe. Touch scenarios run on a phone-shaped page,
+ * mouse scenarios on a desktop-shaped one (the grip is the mouse's drag
+ * surface).
  */
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -60,6 +63,18 @@ async function swipe(cdp: CDPSession, pts: Pt[], { stepMs = 16, holdMs = 0 } = {
   await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
 }
 
+/** The same drag with the mouse (down, stepped moves, up). */
+async function mouseDrag(page: Page, pts: Pt[], { stepMs = 16, holdMs = 0 } = {}) {
+  await page.mouse.move(pts[0].x, pts[0].y);
+  await page.mouse.down();
+  for (let i = 1; i < pts.length; i++) {
+    await sleep(stepMs);
+    await page.mouse.move(pts[i].x, pts[i].y);
+  }
+  if (holdMs) await sleep(holdMs);
+  await page.mouse.up();
+}
+
 const panelState = (page: Page) =>
   page.evaluate(() => {
     const p = document.getElementById('panel')!;
@@ -68,6 +83,10 @@ const panelState = (page: Page) =>
       visibility: getComputedStyle(p).visibility,
       transform: p.style.transform,
       chipShown: !chip.hidden && chip.classList.contains('shown'),
+      pinRight: p.classList.contains('pin-right'),
+      pinBottom: p.classList.contains('pin-bottom'),
+      chipRight: chip.classList.contains('pin-right'),
+      chipBottom: chip.classList.contains('pin-bottom'),
     };
   });
 
@@ -77,7 +96,13 @@ const panelRect = (page: Page) =>
     return { left: r.left, top: r.top, width: r.width, height: r.height };
   });
 
-/** Poll until the panel reports dismissed (or not); throws on timeout. */
+/** A point inside the panel's body (below the grip strip, above examples). */
+const panelBody = async (page: Page, fx: number, fy: number): Promise<Pt> => {
+  const r = await panelRect(page);
+  return { x: r.left + r.width * fx, y: r.top + Math.max(24, r.height * fy) };
+};
+
+/** Poll until the panel reports dismissed (or settled home); throws on timeout. */
 async function waitState(page: Page, want: 'hidden' | 'home', timeout = 2500) {
   const t0 = Date.now();
   for (;;) {
@@ -120,10 +145,11 @@ const browser = await chromium.launch({
 const page = await browser.newPage({ viewport: { width: 390, height: 720 }, hasTouch: true });
 const cdp = await page.context().newCDPSession(page);
 
+// --- touch: dismissal ---
+
 await scenario('flick up dismisses', async () => {
   await load(page, ['y = sin(x)']);
-  const r = await panelRect(page);
-  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.6 };
+  const from = await panelBody(page, 0.5, 0.6);
   // ~160px in ~64ms: an unambiguous flick.
   await swipe(cdp, path(from, { x: from.x, y: from.y - 160 }, 4));
   await waitState(page, 'hidden');
@@ -138,7 +164,7 @@ await scenario('chip tap restores', async () => {
 
 await scenario('short slow drag springs back', async () => {
   const r = await panelRect(page);
-  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.7 };
+  const from = await panelBody(page, 0.5, 0.7);
   // A third of the panel, slowly, resting before release: short of the
   // halfway commit point, and the rest zeroes any leftover momentum.
   await swipe(cdp, path(from, { x: from.x, y: from.y - r.height * 0.35 }, 6), { stepMs: 40, holdMs: 250 });
@@ -148,7 +174,7 @@ await scenario('short slow drag springs back', async () => {
 
 await scenario('slow drag past half dismisses', async () => {
   const r = await panelRect(page);
-  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.8 };
+  const from = await panelBody(page, 0.5, 0.8);
   // Past half the panel with no speed at all: still a dismissal.
   await swipe(cdp, path(from, { x: from.x, y: from.y - r.height * 0.65 }, 10), { stepMs: 40, holdMs: 250 });
   await waitState(page, 'hidden');
@@ -158,8 +184,7 @@ await scenario('slow drag past half dismisses', async () => {
 });
 
 await scenario('flick left dismisses', async () => {
-  const r = await panelRect(page);
-  const from = { x: r.left + r.width * 0.7, y: r.top + r.height * 0.5 };
+  const from = await panelBody(page, 0.7, 0.5);
   await swipe(cdp, path(from, { x: from.x - 150, y: from.y }, 4));
   await waitState(page, 'hidden');
   check('flick left hides the panel too', true);
@@ -167,23 +192,7 @@ await scenario('flick left dismisses', async () => {
   await waitState(page, 'home');
 });
 
-await scenario('drag the wrong way rubber-bands', async () => {
-  const r = await panelRect(page);
-  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.3 };
-  const pts = path(from, { x: from.x + 120, y: from.y + 120 }, 8);
-  // Sample the transform mid-gesture: dispatch the drag but read before lift.
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ ...pts[0], id: 1 }] });
-  for (let i = 1; i < pts.length; i++) {
-    await sleep(16);
-    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ ...pts[i], id: 1 }] });
-  }
-  const mid = await panelState(page);
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
-  const m = mid.transform.match(/translate3d\(([-\d.]+)px, ([-\d.]+)px/);
-  const ok = !!m && Number(m[1]) > 0 && Number(m[1]) < 60 && Number(m[2]) > 0 && Number(m[2]) < 60;
-  check('120px of down-right drag yields a small resisted offset', ok, `transform=${mid.transform}`);
-  await waitState(page, 'home');
-});
+// --- touch: gestures that are not panel drags ---
 
 await scenario('swipe on a scrollable list scrolls it, not the panel', async () => {
   // Enough rows that #equations overflows and owns vertical pans.
@@ -201,6 +210,34 @@ await scenario('swipe on a scrollable list scrolls it, not the panel', async () 
     s.visibility !== 'hidden' && s.transform === '' && scrolled > 0,
     `state=${JSON.stringify(s)} scrollTop=${scrolled}`,
   );
+});
+
+await scenario('focused editor keeps its touches (text selection stays draggable)', async () => {
+  await load(page, ['y = sin(x)', 'y = 2x']);
+  const line = await page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('.eq-line')!;
+    const r = el.getBoundingClientRect();
+    return { x: r.left + 120, y: r.top + r.height / 2 };
+  });
+  await page.touchscreen.tap(line.x, line.y); // focus the editor (caret in)
+  const focused = await page.evaluate(() => document.activeElement?.id === 'equations');
+  // A swipe over the text while editing must not move the panel: on iOS the
+  // same touches drag the caret and the selection handles.
+  await swipe(cdp, path(line, { x: line.x - 130, y: line.y }, 5));
+  const s = await panelState(page);
+  check(
+    'a swipe over focused text leaves the panel alone',
+    focused && s.visibility !== 'hidden' && s.transform === '',
+    `focused=${focused} state=${JSON.stringify(s)}`,
+  );
+  // The grip still works mid-edit: it is the guaranteed drag surface.
+  const r = await panelRect(page);
+  const grip = { x: r.left + r.width / 2, y: r.top + 8 };
+  await swipe(cdp, path(grip, { x: grip.x, y: grip.y - 150 }, 4));
+  await waitState(page, 'hidden');
+  check('the grip still dismisses while the editor is focused', true);
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
 });
 
 await scenario('swipe from the gutter dismisses without recoloring', async () => {
@@ -234,10 +271,12 @@ await scenario('gutter tap still recolors', async () => {
   check('a plain touch tap on the dot cycles the color', after !== line.color, `stuck at ${after}`);
 });
 
+// --- touch: pull-open and catching ---
+
 await scenario('dragging the chip pulls the panel back in', async () => {
   await load(page, ['y = sin(x)']);
-  const r = await panelRect(page);
-  await swipe(cdp, path({ x: r.left + r.width / 2, y: r.top + r.height * 0.6 }, { x: r.left + r.width / 2, y: r.top + r.height * 0.6 - 160 }, 4));
+  const from = await panelBody(page, 0.5, 0.6);
+  await swipe(cdp, path(from, { x: from.x, y: from.y - 160 }, 4));
   await waitState(page, 'hidden');
   const chip = await page.evaluate(() => {
     const c = document.getElementById('panel-chip')!.getBoundingClientRect();
@@ -249,8 +288,8 @@ await scenario('dragging the chip pulls the panel back in', async () => {
   check('a pull on the chip brings the panel home', true);
 
   // Dismiss again and pull only a little: it must park again, chip back.
-  const r2 = await panelRect(page);
-  await swipe(cdp, path({ x: r2.left + r2.width / 2, y: r2.top + r2.height * 0.6 }, { x: r2.left + r2.width / 2, y: r2.top + r2.height * 0.6 - 160 }, 4));
+  const from2 = await panelBody(page, 0.5, 0.6);
+  await swipe(cdp, path(from2, { x: from2.x, y: from2.y - 160 }, 4));
   await waitState(page, 'hidden');
   await swipe(cdp, path(chip, { x: chip.x, y: chip.y + 25 }, 5), { stepMs: 40, holdMs: 250 });
   await waitState(page, 'hidden');
@@ -262,19 +301,103 @@ await scenario('dragging the chip pulls the panel back in', async () => {
 await scenario('the panel can be caught mid-flight', async () => {
   // A tall panel makes for a long flight — long enough to intercept.
   await load(page, Array.from({ length: 8 }, (_, i) => `y = x + ${i}`));
-  const r = await panelRect(page);
-  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.7 };
+  const from = await panelBody(page, 0.5, 0.7);
   // A modest flick: enough to commit the dismissal, slow enough to catch.
   await swipe(cdp, path(from, { x: from.x, y: from.y - 100 }, 6), { stepMs: 24 });
   await sleep(80); // it is now flying off, partly off-screen
   const mid = await panelRect(page);
   if (mid.top + mid.height < 40) throw new Error(`nothing left to catch: ${JSON.stringify(mid)}`);
   const grab = { x: mid.left + mid.width / 2, y: mid.top + mid.height - 25 };
-  // Catch the visible sliver and shove it back down well past home (the
-  // overshoot rubber-bands away), rest, release: it must settle home.
+  // Catch the visible sliver, shove it back toward home, rest, release.
   await swipe(cdp, path(grab, { x: grab.x, y: grab.y + 400 }, 10), { holdMs: 250 });
   await waitState(page, 'home');
   check('a touch during the exit catches the panel and can put it back', true);
+});
+
+// --- touch: corner pinning (last: the chosen corner persists) ---
+
+await scenario('flick down pins the panel to the bottom', async () => {
+  await load(page, ['y = sin(x)']);
+  const from = await panelBody(page, 0.5, 0.4);
+  // A firm downward flick, but nowhere near a bottom-edge dismissal.
+  await swipe(cdp, path(from, { x: from.x, y: from.y + 130 }, 5), { stepMs: 20 });
+  await waitState(page, 'home', 3500);
+  const s = await panelState(page);
+  const r = await panelRect(page);
+  const vh = 720;
+  check(
+    'the panel glided to a bottom corner and re-anchored',
+    s.pinBottom && !s.pinRight && Math.abs(r.top + r.height - (vh - 12)) < 2,
+    `state=${JSON.stringify(s)} rect=${JSON.stringify(r)}`,
+  );
+});
+
+await scenario('dismissing past a bottom corner parks the chip there', async () => {
+  const from = await panelBody(page, 0.5, 0.6);
+  await swipe(cdp, path(from, { x: from.x, y: from.y + 150 }, 4));
+  await waitState(page, 'hidden');
+  const s = await panelState(page);
+  check('the chip took the bottom corner', s.chipBottom && !s.chipRight, JSON.stringify(s));
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
+  const s2 = await panelState(page);
+  check('the panel came back to the same corner', s2.pinBottom && !s2.pinRight, JSON.stringify(s2));
+});
+
+await scenario('the pinned corner persists across a reload', async () => {
+  await page.reload();
+  await page.waitForSelector('.eq-line');
+  const s = await panelState(page);
+  check('a reload boots the panel at its pinned corner', s.pinBottom && !s.pinRight, JSON.stringify(s));
+});
+
+// --- mouse: the grip is the drag surface ---
+
+const desk = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+
+await scenario('mouse-dragging the grip moves the panel to another corner', async () => {
+  await load(desk, ['y = sin(x)']);
+  const r = await panelRect(desk);
+  const grip = { x: r.left + r.width / 2, y: r.top + 8 };
+  // Carry it toward the bottom-right and rest before letting go — this is a
+  // placement, not a throw.
+  await mouseDrag(desk, path(grip, { x: 1000, y: 650 }, 10), { stepMs: 20, holdMs: 250 });
+  await waitState(desk, 'home', 3500);
+  const s = await panelState(desk);
+  check('the panel pinned to the bottom-right', s.pinRight && s.pinBottom, JSON.stringify(s));
+});
+
+await scenario('mouse-flicking the grip off an edge dismisses', async () => {
+  const r = await panelRect(desk);
+  const grip = { x: r.left + r.width / 2, y: r.top + 8 };
+  await mouseDrag(desk, path(grip, { x: grip.x + 220, y: grip.y }, 4));
+  await waitState(desk, 'hidden');
+  const s = await panelState(desk);
+  check('thrown off the right edge; chip at the bottom-right', s.chipRight && s.chipBottom, JSON.stringify(s));
+  await desk.click('#panel-chip');
+  await waitState(desk, 'home');
+  check('clicking the chip restores on desktop', true);
+});
+
+await scenario('a timid mouse pull on the chip parks again, not reopens', async () => {
+  const r = await panelRect(desk);
+  const grip = { x: r.left + r.width / 2, y: r.top + 8 };
+  await mouseDrag(desk, path(grip, { x: grip.x + 220, y: grip.y }, 4));
+  await waitState(desk, 'hidden');
+  const chip = await desk.evaluate(() => {
+    const c = document.getElementById('panel-chip')!.getBoundingClientRect();
+    return { x: c.left + c.width / 2, y: c.top + c.height / 2 };
+  });
+  // A 25px mouse pull, released at rest: parks. The click that follows the
+  // drag must not count as a tap and reopen it.
+  await mouseDrag(desk, path(chip, { x: chip.x - 25, y: chip.y }, 4), { stepMs: 30, holdMs: 250 });
+  await sleep(900);
+  const s = await panelState(desk);
+  check('the panel parked again after the timid pull', s.visibility === 'hidden' && s.chipShown, JSON.stringify(s));
+  // And a real pull opens it.
+  await mouseDrag(desk, path(chip, { x: chip.x - 240, y: chip.y - 120 }, 8), { stepMs: 20 });
+  await waitState(desk, 'home');
+  check('a real mouse pull on the chip opens the panel', true);
 });
 
 await browser.close();

--- a/scripts/swipe-test.ts
+++ b/scripts/swipe-test.ts
@@ -1,0 +1,285 @@
+/**
+ * Browser tests for the panel swipe-to-dismiss gesture: `pnpm test:swipe`.
+ *
+ * The gesture code (web/panel-swipe.ts) is arbitration between native touch
+ * behaviors — scrolling, taps, clicks — and a custom drag, so unit tests of
+ * the physics (lib/fling.test.ts) cannot cover it. This drives the real app
+ * in headless Chromium with CDP-synthesized *trusted* touch input: real hit
+ * testing, real scrolling, real click suppression after a swipe.
+ */
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { type CDPSession, type Page, chromium } from 'playwright';
+
+const PORT = 5198;
+const ORIGIN = `http://localhost:${PORT}`;
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+const results: { name: string; ok: boolean; detail: string }[] = [];
+
+function check(name: string, ok: boolean, detail = '') {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail && !ok ? `\n      ${detail}` : ''}`);
+}
+
+async function scenario(label: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (err) {
+    check(label, false, String(err).split('\n')[0]);
+  }
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+interface Pt {
+  x: number;
+  y: number;
+}
+
+/** Evenly spaced points from `a` to `b`, endpoints included. */
+function path(a: Pt, b: Pt, steps: number): Pt[] {
+  return Array.from({ length: steps + 1 }, (_, i) => ({
+    x: a.x + ((b.x - a.x) * i) / steps,
+    y: a.y + ((b.y - a.y) * i) / steps,
+  }));
+}
+
+/**
+ * One-finger drag through `pts`. Real time passes between moves, so release
+ * velocity is (distance between points) / stepMs; `holdMs` pauses before
+ * lifting, which zeroes it (the stall gate).
+ */
+async function swipe(cdp: CDPSession, pts: Pt[], { stepMs = 16, holdMs = 0 } = {}) {
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ ...pts[0], id: 1 }] });
+  for (let i = 1; i < pts.length; i++) {
+    await sleep(stepMs);
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ ...pts[i], id: 1 }] });
+  }
+  if (holdMs) await sleep(holdMs);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+}
+
+const panelState = (page: Page) =>
+  page.evaluate(() => {
+    const p = document.getElementById('panel')!;
+    const chip = document.getElementById('panel-chip')!;
+    return {
+      visibility: getComputedStyle(p).visibility,
+      transform: p.style.transform,
+      chipShown: !chip.hidden && chip.classList.contains('shown'),
+    };
+  });
+
+const panelRect = (page: Page) =>
+  page.evaluate(() => {
+    const r = document.getElementById('panel')!.getBoundingClientRect();
+    return { left: r.left, top: r.top, width: r.width, height: r.height };
+  });
+
+/** Poll until the panel reports dismissed (or not); throws on timeout. */
+async function waitState(page: Page, want: 'hidden' | 'home', timeout = 2500) {
+  const t0 = Date.now();
+  for (;;) {
+    const s = await panelState(page);
+    if (want === 'hidden' && s.visibility === 'hidden' && s.chipShown) return;
+    if (want === 'home' && s.visibility !== 'hidden' && s.transform === '' && !s.chipShown) return;
+    if (Date.now() - t0 > timeout) {
+      throw new Error(`timed out waiting for ${want}: ${JSON.stringify(s)}`);
+    }
+    await sleep(50);
+  }
+}
+
+async function load(page: Page, rows: string[]) {
+  await page.goto('about:blank');
+  await page.goto(ORIGIN + '/#' + rows.map(encodeURIComponent).join(';'));
+  await page.waitForSelector('.eq-line');
+}
+
+const server = spawn(`${ROOT}node_modules/.bin/vite`, ['--port', String(PORT), '--strictPort'], {
+  cwd: ROOT,
+  stdio: 'ignore',
+});
+process.on('exit', () => server.kill());
+
+for (let i = 0; ; i++) {
+  try {
+    if ((await fetch(ORIGIN)).ok) break;
+  } catch {}
+  if (i > 100) throw new Error(`vite did not come up on ${ORIGIN}`);
+  await new Promise(r => setTimeout(r, 200));
+}
+
+// CHROMIUM overrides the browser binary, for containers with a system build.
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM || undefined,
+  args: ['--enable-unsafe-swiftshader'],
+});
+// A phone-shaped, touch-enabled page: the surface the gesture exists for.
+const page = await browser.newPage({ viewport: { width: 390, height: 720 }, hasTouch: true });
+const cdp = await page.context().newCDPSession(page);
+
+await scenario('flick up dismisses', async () => {
+  await load(page, ['y = sin(x)']);
+  const r = await panelRect(page);
+  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.6 };
+  // ~160px in ~64ms: an unambiguous flick.
+  await swipe(cdp, path(from, { x: from.x, y: from.y - 160 }, 4));
+  await waitState(page, 'hidden');
+  check('flick up hides the panel and shows the chip', true);
+});
+
+await scenario('chip tap restores', async () => {
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
+  check('tapping the chip springs the panel back', true);
+});
+
+await scenario('short slow drag springs back', async () => {
+  const r = await panelRect(page);
+  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.7 };
+  // A third of the panel, slowly, resting before release: short of the
+  // halfway commit point, and the rest zeroes any leftover momentum.
+  await swipe(cdp, path(from, { x: from.x, y: from.y - r.height * 0.35 }, 6), { stepMs: 40, holdMs: 250 });
+  await waitState(page, 'home');
+  check('a hesitant drag settles back home', true);
+});
+
+await scenario('slow drag past half dismisses', async () => {
+  const r = await panelRect(page);
+  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.8 };
+  // Past half the panel with no speed at all: still a dismissal.
+  await swipe(cdp, path(from, { x: from.x, y: from.y - r.height * 0.65 }, 10), { stepMs: 40, holdMs: 250 });
+  await waitState(page, 'hidden');
+  check('carrying the panel past halfway dismisses without a flick', true);
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
+});
+
+await scenario('flick left dismisses', async () => {
+  const r = await panelRect(page);
+  const from = { x: r.left + r.width * 0.7, y: r.top + r.height * 0.5 };
+  await swipe(cdp, path(from, { x: from.x - 150, y: from.y }, 4));
+  await waitState(page, 'hidden');
+  check('flick left hides the panel too', true);
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
+});
+
+await scenario('drag the wrong way rubber-bands', async () => {
+  const r = await panelRect(page);
+  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.3 };
+  const pts = path(from, { x: from.x + 120, y: from.y + 120 }, 8);
+  // Sample the transform mid-gesture: dispatch the drag but read before lift.
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ ...pts[0], id: 1 }] });
+  for (let i = 1; i < pts.length; i++) {
+    await sleep(16);
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ ...pts[i], id: 1 }] });
+  }
+  const mid = await panelState(page);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  const m = mid.transform.match(/translate3d\(([-\d.]+)px, ([-\d.]+)px/);
+  const ok = !!m && Number(m[1]) > 0 && Number(m[1]) < 60 && Number(m[2]) > 0 && Number(m[2]) < 60;
+  check('120px of down-right drag yields a small resisted offset', ok, `transform=${mid.transform}`);
+  await waitState(page, 'home');
+});
+
+await scenario('swipe on a scrollable list scrolls it, not the panel', async () => {
+  // Enough rows that #equations overflows and owns vertical pans.
+  await load(page, Array.from({ length: 40 }, (_, i) => `y = ${i + 1} x`));
+  const box = await page.evaluate(() => {
+    const r = document.getElementById('equations')!.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  });
+  await swipe(cdp, path(box, { x: box.x, y: box.y - 150 }, 6));
+  // Read immediately: a claimed drag would still be translated or animating.
+  const s = await panelState(page);
+  const scrolled = await page.evaluate(() => document.getElementById('equations')!.scrollTop);
+  check(
+    'the list consumed the swipe',
+    s.visibility !== 'hidden' && s.transform === '' && scrolled > 0,
+    `state=${JSON.stringify(s)} scrollTop=${scrolled}`,
+  );
+});
+
+await scenario('swipe from the gutter dismisses without recoloring', async () => {
+  await load(page, ['y = x']);
+  const line = await page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('.eq-line')!;
+    const r = el.getBoundingClientRect();
+    return { x: r.left + 10, y: r.top + r.height / 2, color: el.style.getPropertyValue('--eq-color') };
+  });
+  await swipe(cdp, path({ x: line.x, y: line.y }, { x: line.x, y: line.y - 150 }, 4));
+  await waitState(page, 'hidden');
+  const after = await page.evaluate(
+    () => document.querySelector<HTMLElement>('.eq-line')!.style.getPropertyValue('--eq-color'),
+  );
+  check('gutter-origin swipe left the row color alone', after === line.color, `${line.color} -> ${after}`);
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
+});
+
+await scenario('gutter tap still recolors', async () => {
+  const line = await page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('.eq-line')!;
+    const r = el.getBoundingClientRect();
+    return { x: r.left + 10, y: r.top + r.height / 2, color: el.style.getPropertyValue('--eq-color') };
+  });
+  await page.touchscreen.tap(line.x, line.y);
+  await sleep(100);
+  const after = await page.evaluate(
+    () => document.querySelector<HTMLElement>('.eq-line')!.style.getPropertyValue('--eq-color'),
+  );
+  check('a plain touch tap on the dot cycles the color', after !== line.color, `stuck at ${after}`);
+});
+
+await scenario('dragging the chip pulls the panel back in', async () => {
+  await load(page, ['y = sin(x)']);
+  const r = await panelRect(page);
+  await swipe(cdp, path({ x: r.left + r.width / 2, y: r.top + r.height * 0.6 }, { x: r.left + r.width / 2, y: r.top + r.height * 0.6 - 160 }, 4));
+  await waitState(page, 'hidden');
+  const chip = await page.evaluate(() => {
+    const c = document.getElementById('panel-chip')!.getBoundingClientRect();
+    return { x: c.left + c.width / 2, y: c.top + c.height / 2 };
+  });
+  // Pull well past the parked distance: the panel must follow and open.
+  await swipe(cdp, path(chip, { x: chip.x, y: chip.y + 200 }, 8), { stepMs: 24 });
+  await waitState(page, 'home');
+  check('a pull on the chip brings the panel home', true);
+
+  // Dismiss again and pull only a little: it must park again, chip back.
+  const r2 = await panelRect(page);
+  await swipe(cdp, path({ x: r2.left + r2.width / 2, y: r2.top + r2.height * 0.6 }, { x: r2.left + r2.width / 2, y: r2.top + r2.height * 0.6 - 160 }, 4));
+  await waitState(page, 'hidden');
+  await swipe(cdp, path(chip, { x: chip.x, y: chip.y + 25 }, 5), { stepMs: 40, holdMs: 250 });
+  await waitState(page, 'hidden');
+  check('a timid pull lets the panel park again', true);
+  await page.tap('#panel-chip');
+  await waitState(page, 'home');
+});
+
+await scenario('the panel can be caught mid-flight', async () => {
+  // A tall panel makes for a long flight — long enough to intercept.
+  await load(page, Array.from({ length: 8 }, (_, i) => `y = x + ${i}`));
+  const r = await panelRect(page);
+  const from = { x: r.left + r.width / 2, y: r.top + r.height * 0.7 };
+  // A modest flick: enough to commit the dismissal, slow enough to catch.
+  await swipe(cdp, path(from, { x: from.x, y: from.y - 100 }, 6), { stepMs: 24 });
+  await sleep(80); // it is now flying off, partly off-screen
+  const mid = await panelRect(page);
+  if (mid.top + mid.height < 40) throw new Error(`nothing left to catch: ${JSON.stringify(mid)}`);
+  const grab = { x: mid.left + mid.width / 2, y: mid.top + mid.height - 25 };
+  // Catch the visible sliver and shove it back down well past home (the
+  // overshoot rubber-bands away), rest, release: it must settle home.
+  await swipe(cdp, path(grab, { x: grab.x, y: grab.y + 400 }, 10), { holdMs: 250 });
+  await waitState(page, 'home');
+  check('a touch during the exit catches the panel and can put it back', true);
+});
+
+await browser.close();
+server.kill();
+
+const failed = results.filter(r => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} passed`);
+if (failed.length) process.exit(1);

--- a/web/index.html
+++ b/web/index.html
@@ -52,6 +52,10 @@
   <canvas id="gl"></canvas>
   <canvas id="overlay"></canvas>
   <div id="panel">
+    <!-- Drag affordance for pointers that can't use the panel-wide touch
+         drag (a mouse drag over text means selection): grab here to move the
+         panel between corners or flick it off-screen. See panel-swipe.ts. -->
+    <div id="panel-grip" title="Drag to move the panel; flick it off-screen to hide it" aria-hidden="true"></div>
     <button id="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">☾</button>
     <button id="state-reset" type="button" aria-label="Restart the simulation" title="Restart the simulation" hidden>↻</button>
     <div id="equations" contenteditable="true" role="textbox" aria-multiline="true" aria-label="Equations, one per line" spellcheck="false" autocapitalize="off" autocorrect="off" enterkeyhint="enter"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -64,6 +64,10 @@
       <a id="about-link" href="/about/">about</a>
     </div>
   </div>
+  <!-- The panel's collapsed form: swiping the panel off-screen (touch; see
+       panel-swipe.ts) leaves this chip in its corner. Tap to spring the panel
+       back, or drag to pull it back in. -->
+  <button id="panel-chip" type="button" hidden aria-label="Show the equations">y=</button>
   <noscript>
     <h1>Equation.io — free online graphing calculator</h1>
     <p>

--- a/web/main.ts
+++ b/web/main.ts
@@ -55,6 +55,7 @@ import {
   niceSpacing,
 } from './render2d.ts';
 import { type Camera3D, Renderer3D, type Scene3D, cameraBoxR, drawLabels3D } from './render3d.ts';
+import { initPanelSwipe } from './panel-swipe.ts';
 import { initTheme, onThemeChange, theme, toggleTheme } from './theme.ts';
 
 interface Equation {
@@ -1764,23 +1765,44 @@ listEl.addEventListener('cut', e => {
 
 // Click on a line's left gutter: comment rows toggle their group collapsed
 // (the ::before chevron), other rows cycle their color dot.
-listEl.addEventListener('pointerdown', e => {
+
+/** The equation whose gutter (chevron / color dot) an event lands on. */
+function gutterHit(e: { target: EventTarget | null; clientX: number }): Equation | null {
   const line = e.target instanceof HTMLElement ? e.target.closest('.eq-line') : null;
-  if (!line) return;
-  if (e.clientX - line.getBoundingClientRect().left > 22) return;
+  if (!line) return null;
+  if (e.clientX - line.getBoundingClientRect().left > 22) return null;
   const eq = equations[lineEls().indexOf(line as HTMLElement)];
-  if (!eq || eq.def) return;
+  return !eq || eq.def ? null : eq;
+}
+
+function gutterAct(eq: Equation) {
   if (eq.comment) {
-    e.preventDefault();
     eq.collapsed = !eq.collapsed || undefined;
     reconcile();
     return;
   }
-  e.preventDefault();
   pushUndo(`color:${eq.id}`);
   eq.colorIndex = (eq.colorIndex + 1) % theme.palette.length;
   reconcile();
   requestRender();
+}
+
+// Mouse acts on press. Touch waits for the click — which never comes if the
+// touch turns into a scroll or a panel-dismiss swipe (panel-swipe.ts), so
+// flinging the panel away from the gutter cannot also recolor a row.
+let gutterTouchPending = false;
+listEl.addEventListener('pointerdown', e => {
+  const eq = gutterHit(e);
+  gutterTouchPending = !!eq && e.pointerType === 'touch';
+  if (!eq) return;
+  e.preventDefault(); // keep the caret and selection out of the gutter
+  if (!gutterTouchPending) gutterAct(eq);
+});
+listEl.addEventListener('click', e => {
+  if (!gutterTouchPending) return;
+  gutterTouchPending = false;
+  const eq = gutterHit(e);
+  if (eq) gutterAct(eq);
 });
 
 // Highlight the line holding the caret (no per-line focus to key off).
@@ -2506,6 +2528,13 @@ onThemeChange(() => {
 });
 syncThemeToggle();
 themeToggle?.addEventListener('click', toggleTheme);
+
+// --- panel swipe (mobile) ---
+
+// On a phone the panel covers most of the graph; a swipe throws it off-screen
+// (up or to the side — it follows the finger and leaves along the flick), and
+// the y= chip it leaves behind brings it back.
+initPanelSwipe(document.getElementById('panel')!, document.getElementById('panel-chip')!);
 
 // --- boot ---
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -2529,12 +2529,19 @@ onThemeChange(() => {
 syncThemeToggle();
 themeToggle?.addEventListener('click', toggleTheme);
 
-// --- panel swipe (mobile) ---
+// --- panel flinging ---
 
-// On a phone the panel covers most of the graph; a swipe throws it off-screen
-// (up or to the side — it follows the finger and leaves along the flick), and
-// the y= chip it leaves behind brings it back.
-initPanelSwipe(document.getElementById('panel')!, document.getElementById('panel-chip')!);
+// The panel is a corner-pinned floating card: flick it (touch anywhere on
+// it; mouse via the grip strip) to another corner, or throw it past any
+// edge to dismiss it — the y= chip it leaves behind brings it back. The
+// equation list is passed in so text gestures (iOS caret and selection-
+// handle drags) are never mistaken for throws.
+initPanelSwipe(
+  document.getElementById('panel')!,
+  document.getElementById('panel-chip')!,
+  document.getElementById('panel-grip')!,
+  listEl,
+);
 
 // --- boot ---
 

--- a/web/panel-swipe.ts
+++ b/web/panel-swipe.ts
@@ -1,0 +1,431 @@
+/**
+ * Swipe-to-dismiss for the equations panel — the mobile way to get the panel
+ * off the graph.
+ *
+ * The gesture follows Apple's touch grammar: from the first move the panel is
+ * pinned to the finger (drag it up, left, or diagonally — both exits work),
+ * directions that cannot dismiss give with a rubber band, and release
+ * projects the remaining momentum: carried or flicked past halfway the panel
+ * flies off along the throw line, otherwise it springs back home. Every
+ * animation is a spring seeded with the release velocity, so motion is
+ * continuous through the release — and interruptible: a new touch picks the
+ * panel up wherever the animation currently holds it. Once dismissed, a
+ * `y=` chip appears in the panel's corner; tapping it springs the panel
+ * back, and dragging it pulls the panel back in under the finger.
+ *
+ * Touch-only by design. On a phone the panel covers most of the graph and
+ * earns its dismissal; with a mouse it never needs to move — and a mouse
+ * drag over text means selection, not throwing furniture. All physics and
+ * decision math is lib/fling.ts, under test; this module owns the events,
+ * the scroll-vs-swipe arbitration, and the styles.
+ */
+
+import {
+  type Sample,
+  type Spring,
+  type Vec2,
+  claimGesture,
+  exitDistances,
+  exitTarget,
+  makeSpring,
+  releaseVelocity,
+  rubberband,
+  shouldDismiss,
+  shouldOpen,
+  stepSpring,
+} from '../lib/fling.ts';
+
+/** Extra travel past the screen edge so the drop shadow fully clears too. */
+const EXIT_PAD = 28;
+/** Movement before a touch commits to being a drag at all (px). */
+const SLOP = 9;
+
+export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
+  const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)');
+
+  /** The panel's translation from its at-rest place; (0,0) is home. */
+  const offset: Vec2 = { x: 0, y: 0 };
+  let hidden = false;
+  /** Unit direction the panel last left in; reopening retraces it. */
+  let exitDir: Vec2 = { x: 0, y: -1 };
+  /** Exit travel per axis, for the outbound fade; refreshed per gesture. */
+  let dists: Vec2 = { x: 1, y: 1 };
+
+  // --- geometry ---
+
+  /** The panel's at-rest viewport box (its live rect minus our transform). */
+  const baseBox = () => {
+    const r = panel.getBoundingClientRect();
+    return { left: r.left - offset.x, top: r.top - offset.y, width: r.width, height: r.height };
+  };
+
+  /** Where a hidden panel parks: just fully off-screen along exitDir.
+   *  Recomputed from live geometry, so rotations while hidden can't strand
+   *  the panel half-visible when it returns. */
+  const parkedOffset = (): Vec2 =>
+    exitTarget({ x: 0, y: 0 }, { x: exitDir.x * 1e4, y: exitDir.y * 1e4 }, exitDistances(baseBox(), EXIT_PAD));
+
+  // --- painting ---
+
+  function paint() {
+    const out = Math.min(1, Math.max(-offset.x / dists.x, -offset.y / dists.y, 0));
+    panel.style.transform = offset.x || offset.y ? `translate3d(${offset.x}px, ${offset.y}px, 0)` : '';
+    // A light fade on the way out reads as speed; squared so the drag range
+    // barely dims and the flight does the fading.
+    panel.style.opacity = out ? String(1 - 0.5 * out * out) : '';
+  }
+
+  function showChip() {
+    chip.hidden = false;
+    void chip.offsetWidth; // commit the hidden pose, so .shown transitions from it
+    chip.classList.add('shown');
+  }
+
+  function hideChip() {
+    chip.classList.remove('shown');
+    chip.hidden = true;
+  }
+
+  // --- the spring loop ---
+  //
+  // One rAF loop integrating an x and a y spring toward home or the exit
+  // point. State lives in module scope rather than in an animation object so
+  // a touch can stop the loop and adopt `offset` mid-flight — catching the
+  // panel is just "the finger is the integrator now".
+
+  let sx: Spring | null = null;
+  let sy: Spring | null = null;
+  let raf = 0;
+  let lastT = 0;
+  let restDist = 0.5;
+  let restSpeed = 20;
+  let onRest: (() => void) | null = null;
+
+  function animateTo(
+    target: Vec2,
+    v: Vec2,
+    response: number,
+    damping: number,
+    done: (() => void) | null,
+    rest: [number, number] = [0.5, 20],
+  ) {
+    sx = makeSpring(offset.x, v.x, target.x, response, damping);
+    sy = makeSpring(offset.y, v.y, target.y, response, damping);
+    [restDist, restSpeed] = rest;
+    onRest = done;
+    if (!raf) {
+      lastT = performance.now();
+      raf = requestAnimationFrame(tick);
+    }
+  }
+
+  function tick(t: number) {
+    raf = 0;
+    const dt = (t - lastT) / 1000;
+    lastT = t;
+    if (!sx || !sy) return;
+    const moveX = stepSpring(sx, dt, restDist, restSpeed);
+    const moveY = stepSpring(sy, dt, restDist, restSpeed);
+    offset.x = sx.x;
+    offset.y = sy.x;
+    paint();
+    if (moveX || moveY) {
+      raf = requestAnimationFrame(tick);
+    } else {
+      sx = sy = null;
+      const cb = onRest;
+      onRest = null;
+      cb?.();
+    }
+  }
+
+  function stopAnim() {
+    if (raf) cancelAnimationFrame(raf);
+    raf = 0;
+    sx = sy = null;
+    onRest = null;
+  }
+
+  /** Back at rest and untouched: drop the compositing hints. */
+  function idle() {
+    if (!offset.x && !offset.y && !raf && !gesture) panel.style.willChange = '';
+  }
+
+  // --- transitions ---
+
+  function finishDismiss() {
+    hidden = true;
+    panel.style.visibility = 'hidden';
+    panel.style.willChange = '';
+    showChip();
+  }
+
+  function dismiss(v: Vec2) {
+    // Drop the keyboard with the panel; the graph is what's being revealed.
+    if (panel.contains(document.activeElement)) (document.activeElement as HTMLElement).blur();
+    const d = exitDistances(baseBox(), EXIT_PAD);
+    dists = d;
+    const target = exitTarget(offset, v, d);
+    const len = Math.hypot(target.x, target.y) || 1;
+    exitDir = { x: target.x / len, y: target.y / len };
+    if (reduceMotion.matches) {
+      offset.x = target.x;
+      offset.y = target.y;
+      paint();
+      finishDismiss();
+      return;
+    }
+    // Critically damped and quick: a thrown thing leaves fast, and any
+    // overshoot would land off-screen where nobody could see it anyway.
+    // Loose rest tolerances for the same reason.
+    animateTo(target, v, 0.32, 1, finishDismiss, [6, 60]);
+  }
+
+  function settle(v: Vec2) {
+    if (reduceMotion.matches) {
+      offset.x = 0;
+      offset.y = 0;
+      paint();
+      idle();
+      return;
+    }
+    // Slightly underdamped: the panel arrives with one soft bounce.
+    animateTo({ x: 0, y: 0 }, v, 0.4, 0.78, idle);
+  }
+
+  function present() {
+    if (!hidden) return;
+    hideChip();
+    hidden = false;
+    panel.style.visibility = '';
+    const from = parkedOffset();
+    offset.x = from.x;
+    offset.y = from.y;
+    dists = exitDistances(baseBox(), EXIT_PAD);
+    if (reduceMotion.matches) {
+      offset.x = 0;
+      offset.y = 0;
+      paint();
+      return;
+    }
+    panel.style.willChange = 'transform, opacity';
+    paint();
+    animateTo({ x: 0, y: 0 }, { x: 0, y: 0 }, 0.42, 0.8, idle);
+  }
+
+  // --- touch handling ---
+
+  interface Gesture {
+    id: number;
+    /** Touch start, client coords. */
+    x0: number;
+    y0: number;
+    /** Where the panel was when the touch began (pull space, unrubbered). */
+    base: Vec2;
+    claimed: boolean;
+    /** Ceded to a scrollable: ignore this touch for the rest of its life. */
+    dead: boolean;
+    /** Dragging the panel back in from the chip. */
+    pull: boolean;
+    scroll: { up: boolean; down: boolean } | null;
+    samples: Sample[];
+  }
+
+  let gesture: Gesture | null = null;
+
+  /**
+   * The scrollable under the touch (the equation list or the examples tree)
+   * and which ways it can currently move — the input claimGesture arbitrates
+   * on. First match wins: they don't nest, and overscroll-behavior keeps a
+   * scroll that hits its end from chaining anywhere.
+   */
+  function scrollableAt(el: Element | null): { up: boolean; down: boolean } | null {
+    for (let n = el; n && n !== panel.parentElement; n = n.parentElement) {
+      if (n.scrollHeight > n.clientHeight + 1) {
+        const oy = getComputedStyle(n).overflowY;
+        if (oy === 'auto' || oy === 'scroll') {
+          return { up: n.scrollTop > 0, down: n.scrollTop + n.clientHeight < n.scrollHeight - 1 };
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Free toward dismissal, rubber away from it. */
+  const shape = (pull: number) => (pull <= 0 ? pull : rubberband(pull));
+  /** Pull-open space: clamped at the parked spot, rubbering past home. */
+  const shapePull = (raw: number, parked: number) =>
+    raw > 0 ? rubberband(raw) : Math.max(raw, parked);
+
+  const trackedTouch = (e: TouchEvent) => {
+    const g = gesture;
+    if (!g) return null;
+    for (const t of e.changedTouches) if (t.identifier === g.id) return t;
+    return null;
+  };
+
+  panel.addEventListener(
+    'touchstart',
+    e => {
+      if (hidden || gesture || e.touches.length > 1) return;
+      const t = e.changedTouches[0];
+      // Range sliders and bound inputs own their drags outright. Buttons,
+      // links and the editor text stay grabbable: a tap on them never crosses
+      // the slop, and once a swipe claims the touch no click follows.
+      if (t.target instanceof Element && t.target.closest('input, select, textarea')) return;
+      const flying = raf !== 0;
+      if (flying) stopAnim();
+      gesture = {
+        id: t.identifier,
+        x0: t.clientX,
+        y0: t.clientY,
+        base: { x: offset.x, y: offset.y },
+        claimed: flying, // a caught panel is already in hand
+        dead: false,
+        pull: false,
+        scroll: t.target instanceof Element ? scrollableAt(t.target) : null,
+        samples: [{ t: e.timeStamp, x: t.clientX, y: t.clientY }],
+      };
+      dists = exitDistances(baseBox(), EXIT_PAD);
+      panel.style.willChange = 'transform, opacity';
+    },
+    { passive: true },
+  );
+
+  panel.addEventListener(
+    'touchmove',
+    e => {
+      const g = gesture;
+      if (!g || g.pull || g.dead) return;
+      const t = trackedTouch(e);
+      if (!t) return;
+      g.samples.push({ t: e.timeStamp, x: t.clientX, y: t.clientY });
+      if (g.samples.length > 32) g.samples.shift();
+      const dx = t.clientX - g.x0;
+      const dy = t.clientY - g.y0;
+      if (!g.claimed) {
+        const claim = claimGesture(dx, dy, g.scroll, SLOP);
+        if (claim === 'undecided') return;
+        if (claim === 'scroll') {
+          g.dead = true;
+          return;
+        }
+        g.claimed = true;
+        // The touch is a panel drag now: drop the soft keyboard so the graph
+        // it reveals is visible, not the keyboard's letterbox.
+        if (panel.contains(document.activeElement)) (document.activeElement as HTMLElement).blur();
+      }
+      if (e.cancelable) e.preventDefault(); // ours: no scroll, no selection
+      offset.x = shape(g.base.x + dx);
+      offset.y = shape(g.base.y + dy);
+      paint();
+    },
+    { passive: false },
+  );
+
+  const endPanelTouch = (e: TouchEvent) => {
+    const g = gesture;
+    if (!g || g.pull) return;
+    if (!trackedTouch(e)) return;
+    gesture = null;
+    if (!g.claimed || g.dead) {
+      idle();
+      return;
+    }
+    if (e.type === 'touchcancel') {
+      settle({ x: 0, y: 0 });
+      return;
+    }
+    const v = releaseVelocity(g.samples, e.timeStamp);
+    if (shouldDismiss(offset, v, baseBox())) dismiss(v);
+    else settle(v);
+  };
+  panel.addEventListener('touchend', endPanelTouch);
+  panel.addEventListener('touchcancel', endPanelTouch);
+
+  // --- the chip: tap to bring the panel back, or drag it back in ---
+
+  chip.addEventListener('click', () => {
+    if (gesture?.pull) return;
+    present();
+  });
+
+  chip.addEventListener(
+    'touchstart',
+    e => {
+      if (!hidden || gesture || e.touches.length > 1) return;
+      const t = e.changedTouches[0];
+      gesture = {
+        id: t.identifier,
+        x0: t.clientX,
+        y0: t.clientY,
+        base: { x: 0, y: 0 },
+        claimed: false,
+        dead: false,
+        pull: true,
+        scroll: null,
+        samples: [{ t: e.timeStamp, x: t.clientX, y: t.clientY }],
+      };
+    },
+    { passive: true },
+  );
+
+  chip.addEventListener(
+    'touchmove',
+    e => {
+      const g = gesture;
+      if (!g?.pull) return;
+      const t = trackedTouch(e);
+      if (!t) return;
+      g.samples.push({ t: e.timeStamp, x: t.clientX, y: t.clientY });
+      if (g.samples.length > 32) g.samples.shift();
+      const dx = t.clientX - g.x0;
+      const dy = t.clientY - g.y0;
+      if (!g.claimed) {
+        if (dx * dx + dy * dy < SLOP * SLOP) return;
+        // The drag becomes the panel: park it under the finger and pull.
+        g.claimed = true;
+        g.base = parkedOffset();
+        hidden = false;
+        panel.style.visibility = '';
+        hideChip();
+        dists = exitDistances(baseBox(), EXIT_PAD);
+        panel.style.willChange = 'transform, opacity';
+      }
+      if (e.cancelable) e.preventDefault();
+      offset.x = shapePull(g.base.x + dx, g.base.x);
+      offset.y = shapePull(g.base.y + dy, g.base.y);
+      paint();
+    },
+    { passive: false },
+  );
+
+  const endChipTouch = (e: TouchEvent) => {
+    const g = gesture;
+    if (!g?.pull) return;
+    if (!trackedTouch(e)) return;
+    gesture = null;
+    if (!g.claimed) return; // a tap: the click that follows presents
+    const v = releaseVelocity(g.samples, e.timeStamp);
+    const open = e.type !== 'touchcancel' && shouldOpen(offset, v, g.base);
+    if (reduceMotion.matches) {
+      if (open) {
+        offset.x = 0;
+        offset.y = 0;
+        paint();
+        panel.style.willChange = '';
+      } else {
+        offset.x = g.base.x;
+        offset.y = g.base.y;
+        paint();
+        finishDismiss();
+      }
+      return;
+    }
+    if (open) animateTo({ x: 0, y: 0 }, v, 0.42, 0.8, idle);
+    // Not pulled far enough: park it again and bring the chip back.
+    else animateTo(g.base, v, 0.36, 1, finishDismiss, [6, 60]);
+  };
+  chip.addEventListener('touchend', endChipTouch);
+  chip.addEventListener('touchcancel', endChipTouch);
+}

--- a/web/panel-swipe.ts
+++ b/web/panel-swipe.ts
@@ -1,77 +1,140 @@
 /**
- * Swipe-to-dismiss for the equations panel — the mobile way to get the panel
- * off the graph.
+ * Swipe-to-move and swipe-to-dismiss for the equations panel.
  *
- * The gesture follows Apple's touch grammar: from the first move the panel is
- * pinned to the finger (drag it up, left, or diagonally — both exits work),
- * directions that cannot dismiss give with a rubber band, and release
- * projects the remaining momentum: carried or flicked past halfway the panel
- * flies off along the throw line, otherwise it springs back home. Every
+ * The panel is a corner-pinned floating card, Apple's picture-in-picture
+ * grammar: from the first move it is pinned to the pointer, and release
+ * decides by projected momentum — thrown more than half past any screen
+ * edge it flies off along the throw line and a `y=` chip takes the nearest
+ * corner; otherwise it glides to whichever corner the projected point
+ * belongs to, so a soft directional flick sends it across the screen. Every
  * animation is a spring seeded with the release velocity, so motion is
  * continuous through the release — and interruptible: a new touch picks the
- * panel up wherever the animation currently holds it. Once dismissed, a
- * `y=` chip appears in the panel's corner; tapping it springs the panel
- * back, and dragging it pulls the panel back in under the finger.
+ * panel up wherever the animation currently holds it. Tapping the chip
+ * springs the panel back; dragging the chip pulls it back in under the
+ * finger. The chosen corner persists across visits.
  *
- * Touch-only by design. On a phone the panel covers most of the graph and
- * earns its dismissal; with a mouse it never needs to move — and a mouse
- * drag over text means selection, not throwing furniture. All physics and
- * decision math is lib/fling.ts, under test; this module owns the events,
- * the scroll-vs-swipe arbitration, and the styles.
+ * Touches drag from anywhere on the panel (scrolling lists and slider
+ * thumbs still win their own gestures, and while the editor is focused or
+ * holds a selection its text is ceded entirely — iOS caret and selection-
+ * handle drags dispatch plain touches at the text, and hijacking those
+ * would break text editing). The grip strip along the top edge drags with
+ * any pointer, which is the mouse's way in: elsewhere on the panel a mouse
+ * drag means text selection, not throwing furniture.
+ *
+ * All physics and decision math is lib/fling.ts, under test; this module
+ * owns the events, the scroll-vs-swipe arbitration, and the styles.
  */
 
 import {
+  CORNER_PROJECT_S,
   type Sample,
   type Spring,
   type Vec2,
   claimGesture,
-  exitDistances,
-  exitTarget,
+  cornerPositions,
+  dismissEdge,
+  exitRay,
   makeSpring,
+  nearestCorner,
+  project,
   releaseVelocity,
   rubberband,
-  shouldDismiss,
   shouldOpen,
   stepSpring,
+  throwDir,
 } from '../lib/fling.ts';
 
 /** Extra travel past the screen edge so the drop shadow fully clears too. */
 const EXIT_PAD = 28;
-/** Movement before a touch commits to being a drag at all (px). */
+/** Movement before a pointer commits to being a drag at all (px). */
 const SLOP = 9;
+/** The corner the panel was last pinned to, kept across visits. */
+const CORNER_KEY = 'eq-panel-corner';
 
-export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
+export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement, grip: HTMLElement, editor: HTMLElement): void {
   const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)');
 
-  /** The panel's translation from its at-rest place; (0,0) is home. */
+  /** Which corner the panel is pinned to: 0 TL, 1 TR, 2 BL, 3 BR. */
+  let corner = 0;
+  try {
+    const n = Number(localStorage.getItem(CORNER_KEY));
+    if (n >= 0 && n <= 3) corner = Math.floor(n);
+  } catch {}
+
+  /** The panel's translation from its pinned rest position; (0,0) is home. */
   const offset: Vec2 = { x: 0, y: 0 };
   let hidden = false;
   /** Unit direction the panel last left in; reopening retraces it. */
   let exitDir: Vec2 = { x: 0, y: -1 };
-  /** Exit travel per axis, for the outbound fade; refreshed per gesture. */
-  let dists: Vec2 = { x: 1, y: 1 };
+
+  /** Apply a corner's anchor classes: CSS anchoring (not a transform) so a
+   *  bottom-pinned panel grows upward when equations are added. */
+  const pin = (el: HTMLElement, i: number) => {
+    el.classList.toggle('pin-right', i % 2 === 1);
+    el.classList.toggle('pin-bottom', i >= 2);
+  };
+  pin(panel, corner);
+  pin(chip, corner);
 
   // --- geometry ---
 
-  /** The panel's at-rest viewport box (its live rect minus our transform). */
-  const baseBox = () => {
-    const r = panel.getBoundingClientRect();
-    return { left: r.left - offset.x, top: r.top - offset.y, width: r.width, height: r.height };
+  // env(safe-area-inset-*) is not readable from JS directly; a fixed probe
+  // with the insets as padding resolves them to pixels on demand.
+  const probe = document.createElement('div');
+  probe.style.cssText = 'position:fixed;inset:0;visibility:hidden;pointer-events:none;'
+    + 'padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left)';
+  document.body.append(probe);
+
+  const margins = () => {
+    const s = getComputedStyle(probe);
+    return {
+      top: 12 + (parseFloat(s.paddingTop) || 0),
+      right: 12 + (parseFloat(s.paddingRight) || 0),
+      bottom: 12 + (parseFloat(s.paddingBottom) || 0),
+      left: 12 + (parseFloat(s.paddingLeft) || 0),
+    };
   };
 
-  /** Where a hidden panel parks: just fully off-screen along exitDir.
-   *  Recomputed from live geometry, so rotations while hidden can't strand
-   *  the panel half-visible when it returns. */
-  const parkedOffset = (): Vec2 =>
-    exitTarget({ x: 0, y: 0 }, { x: exitDir.x * 1e4, y: exitDir.y * 1e4 }, exitDistances(baseBox(), EXIT_PAD));
+  interface Geo {
+    /** Absolute top-left of the current pin's rest spot. */
+    rest: Vec2;
+    w: number;
+    h: number;
+    vw: number;
+    vh: number;
+    /** Rest positions of all four corners for the current panel size. */
+    corners: Vec2[];
+  }
+
+  /** Measured once per gesture/animation, so per-frame paint stays pure math. */
+  const measure = (): Geo => {
+    const r = panel.getBoundingClientRect();
+    const vw = document.documentElement.clientWidth;
+    const vh = document.documentElement.clientHeight;
+    return {
+      rest: { x: r.left - offset.x, y: r.top - offset.y },
+      w: r.width,
+      h: r.height,
+      vw,
+      vh,
+      corners: cornerPositions(vw, vh, r.width, r.height, margins()),
+    };
+  };
+  let geo = measure();
 
   // --- painting ---
 
   function paint() {
-    const out = Math.min(1, Math.max(-offset.x / dists.x, -offset.y / dists.y, 0));
+    const { rest, w, h, vw, vh } = geo;
+    const x = rest.x + offset.x;
+    const y = rest.y + offset.y;
+    // A light fade once the panel starts leaving the screen; squared so the
+    // on-screen range barely dims and the flight does the fading.
+    const out = Math.min(
+      1,
+      Math.max(-x / (w + EXIT_PAD), (x + w - vw) / (w + EXIT_PAD), -y / (h + EXIT_PAD), (y + h - vh) / (h + EXIT_PAD), 0),
+    );
     panel.style.transform = offset.x || offset.y ? `translate3d(${offset.x}px, ${offset.y}px, 0)` : '';
-    // A light fade on the way out reads as speed; squared so the drag range
-    // barely dims and the flight does the fading.
     panel.style.opacity = out ? String(1 - 0.5 * out * out) : '';
   }
 
@@ -88,9 +151,9 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
 
   // --- the spring loop ---
   //
-  // One rAF loop integrating an x and a y spring toward home or the exit
+  // One rAF loop integrating an x and a y spring toward a corner or the exit
   // point. State lives in module scope rather than in an animation object so
-  // a touch can stop the loop and adopt `offset` mid-flight — catching the
+  // a pointer can stop the loop and adopt `offset` mid-flight — catching the
   // panel is just "the finger is the integrator now".
 
   let sx: Spring | null = null;
@@ -153,44 +216,75 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
 
   // --- transitions ---
 
-  function finishDismiss() {
+  /** Pin panel and chip to corner `i` and make it the new zero. Only valid
+   *  when the panel is at rest exactly on that corner (or hidden): the CSS
+   *  re-anchor and the cleared transform land on the same rect. */
+  function setCorner(i: number) {
+    corner = i;
+    try {
+      localStorage.setItem(CORNER_KEY, String(i));
+    } catch {} // private mode: the corner just won't stick across visits
+    pin(panel, i);
+    pin(chip, i);
+    offset.x = 0;
+    offset.y = 0;
+    panel.style.transform = '';
+    panel.style.opacity = '';
+  }
+
+  function finishDismiss(exitPos: Vec2) {
+    // The chip takes the corner nearest where the panel left — which is also
+    // where it will come back to.
+    setCorner(nearestCorner(exitPos, geo.corners));
     hidden = true;
     panel.style.visibility = 'hidden';
     panel.style.willChange = '';
     showChip();
   }
 
-  function dismiss(v: Vec2) {
-    // Drop the keyboard with the panel; the graph is what's being revealed.
-    if (panel.contains(document.activeElement)) (document.activeElement as HTMLElement).blur();
-    const d = exitDistances(baseBox(), EXIT_PAD);
-    dists = d;
-    const target = exitTarget(offset, v, d);
-    const len = Math.hypot(target.x, target.y) || 1;
-    exitDir = { x: target.x / len, y: target.y / len };
+  /** Shared release decision for panel drags (touch and grip alike). */
+  function releasePanel(v: Vec2, startOffset: Vec2) {
+    const { rest, w, h, vw, vh, corners } = geo;
+    const pos = { x: rest.x + offset.x, y: rest.y + offset.y };
+    const edge = dismissEdge(project(pos, v), w, h, vw, vh);
+    if (edge) {
+      // Drop the keyboard with the panel; the graph is what's being revealed.
+      if (panel.contains(document.activeElement)) (document.activeElement as HTMLElement).blur();
+      const disp = { x: offset.x - startOffset.x, y: offset.y - startOffset.y };
+      const dir = throwDir(v, disp, edge);
+      const len = Math.hypot(dir.x, dir.y) || 1;
+      exitDir = { x: dir.x / len, y: dir.y / len };
+      const exit = exitRay(pos, dir, w, h, vw, vh, EXIT_PAD);
+      const target = { x: exit.x - rest.x, y: exit.y - rest.y };
+      if (reduceMotion.matches) {
+        offset.x = target.x;
+        offset.y = target.y;
+        paint();
+        finishDismiss(exit);
+        return;
+      }
+      // Critically damped and quick: a thrown thing leaves fast, and any
+      // overshoot would land off-screen where nobody could see it anyway.
+      // Loose rest tolerances for the same reason.
+      animateTo(target, v, 0.32, 1, () => finishDismiss(exit), [6, 60]);
+      return;
+    }
+    // Not a dismissal: the projected point picks the corner (the PiP rule).
+    const i = nearestCorner(project(pos, v, CORNER_PROJECT_S), corners);
+    const target = { x: corners[i].x - rest.x, y: corners[i].y - rest.y };
     if (reduceMotion.matches) {
       offset.x = target.x;
       offset.y = target.y;
       paint();
-      finishDismiss();
-      return;
-    }
-    // Critically damped and quick: a thrown thing leaves fast, and any
-    // overshoot would land off-screen where nobody could see it anyway.
-    // Loose rest tolerances for the same reason.
-    animateTo(target, v, 0.32, 1, finishDismiss, [6, 60]);
-  }
-
-  function settle(v: Vec2) {
-    if (reduceMotion.matches) {
-      offset.x = 0;
-      offset.y = 0;
-      paint();
+      setCorner(i);
       idle();
       return;
     }
-    // Slightly underdamped: the panel arrives with one soft bounce.
-    animateTo({ x: 0, y: 0 }, v, 0.4, 0.78, idle);
+    // A glide with one soft arrival bounce; the finger's speed carries in.
+    animateTo(target, v, 0.45, 0.85, () => {
+      setCorner(i);
+      idle();
+    });
   }
 
   function present() {
@@ -198,10 +292,10 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
     hideChip();
     hidden = false;
     panel.style.visibility = '';
-    const from = parkedOffset();
-    offset.x = from.x;
-    offset.y = from.y;
-    dists = exitDistances(baseBox(), EXIT_PAD);
+    geo = measure(); // offset is (0,0) while parked, so this reads the rest box
+    const parked = exitRay(geo.rest, exitDir, geo.w, geo.h, geo.vw, geo.vh, EXIT_PAD);
+    offset.x = parked.x - geo.rest.x;
+    offset.y = parked.y - geo.rest.y;
     if (reduceMotion.matches) {
       offset.x = 0;
       offset.y = 0;
@@ -213,20 +307,25 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
     animateTo({ x: 0, y: 0 }, { x: 0, y: 0 }, 0.42, 0.8, idle);
   }
 
-  // --- touch handling ---
+  // --- gestures ---
 
   interface Gesture {
+    /** Touch identifier or pointerId. */
     id: number;
-    /** Touch start, client coords. */
+    /** Pointer start, client coords. */
     x0: number;
     y0: number;
-    /** Where the panel was when the touch began (pull space, unrubbered). */
+    /** Where the panel was when the pointer landed. */
     base: Vec2;
+    startOffset: Vec2;
     claimed: boolean;
-    /** Ceded to a scrollable: ignore this touch for the rest of its life. */
+    /** Ceded to a scrollable or the text editor: ignore until it ends. */
     dead: boolean;
     /** Dragging the panel back in from the chip. */
     pull: boolean;
+    /** Driven by pointer events on the grip/chip (mouse or pen). */
+    mouse: boolean;
+    fromEditor: boolean;
     scroll: { up: boolean; down: boolean } | null;
     samples: Sample[];
   }
@@ -251,11 +350,28 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
     return null;
   }
 
-  /** Free toward dismissal, rubber away from it. */
-  const shape = (pull: number) => (pull <= 0 ? pull : rubberband(pull));
-  /** Pull-open space: clamped at the parked spot, rubbering past home. */
-  const shapePull = (raw: number, parked: number) =>
-    raw > 0 ? rubberband(raw) : Math.max(raw, parked);
+  /** A live selection in the editor: its iOS drag handles dispatch plain
+   *  touchmoves at the text, so those touches are never ours to claim. */
+  const editorSelection = (): boolean => {
+    const sel = getSelection();
+    return !!sel && !sel.isCollapsed && sel.anchorNode !== null && editor.contains(sel.anchorNode);
+  };
+
+  /** While focused (caret dragging, keyboard up) or holding a selection, the
+   *  editor owns every touch on its text. */
+  const editorOwnsTouches = (): boolean => {
+    const a = document.activeElement;
+    return a === editor || (!!a && editor.contains(a)) || editorSelection();
+  };
+
+  /** Pull-open space: free between the parked spot and home, rubbering past
+   *  home and stopped just past the parked spot. Sign-aware — the panel may
+   *  be parked off any side of the screen. */
+  const shapePull = (raw: number, parked: number): number => {
+    if (parked < 0) return raw >= 0 ? rubberband(raw) : Math.max(raw, parked);
+    if (parked > 0) return raw <= 0 ? -rubberband(-raw) : Math.min(raw, parked);
+    return Math.sign(raw) * rubberband(Math.abs(raw));
+  };
 
   const trackedTouch = (e: TouchEvent) => {
     const g = gesture;
@@ -264,30 +380,47 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
     return null;
   };
 
+  function startPanelGesture(id: number, x: number, y: number, t: number, opts: { claimed: boolean; mouse: boolean; fromEditor: boolean; scroll: Gesture['scroll'] }) {
+    const flying = raf !== 0;
+    if (flying) stopAnim();
+    gesture = {
+      id,
+      x0: x,
+      y0: y,
+      base: { x: offset.x, y: offset.y },
+      startOffset: { x: offset.x, y: offset.y },
+      claimed: opts.claimed || flying, // a caught panel is already in hand
+      dead: false,
+      pull: false,
+      mouse: opts.mouse,
+      fromEditor: opts.fromEditor,
+      scroll: opts.scroll,
+      samples: [{ t, x, y }],
+    };
+    geo = measure();
+    panel.style.willChange = 'transform, opacity';
+  }
+
+  // --- panel touches: drag from anywhere that isn't someone else's gesture ---
+
   panel.addEventListener(
     'touchstart',
     e => {
       if (hidden || gesture || e.touches.length > 1) return;
       const t = e.changedTouches[0];
+      if (!(t.target instanceof Element)) return;
       // Range sliders and bound inputs own their drags outright. Buttons,
-      // links and the editor text stay grabbable: a tap on them never crosses
-      // the slop, and once a swipe claims the touch no click follows.
-      if (t.target instanceof Element && t.target.closest('input, select, textarea')) return;
-      const flying = raf !== 0;
-      if (flying) stopAnim();
-      gesture = {
-        id: t.identifier,
-        x0: t.clientX,
-        y0: t.clientY,
-        base: { x: offset.x, y: offset.y },
-        claimed: flying, // a caught panel is already in hand
-        dead: false,
-        pull: false,
-        scroll: t.target instanceof Element ? scrollableAt(t.target) : null,
-        samples: [{ t: e.timeStamp, x: t.clientX, y: t.clientY }],
-      };
-      dists = exitDistances(baseBox(), EXIT_PAD);
-      panel.style.willChange = 'transform, opacity';
+      // links and (unfocused) editor text stay grabbable: a tap on them never
+      // crosses the slop, and once a swipe claims the touch no click follows.
+      if (t.target.closest('input, select, textarea')) return;
+      const fromEditor = editor.contains(t.target);
+      if (fromEditor && editorOwnsTouches()) return; // caret/selection drags are text edits, not throws
+      startPanelGesture(t.identifier, t.clientX, t.clientY, e.timeStamp, {
+        claimed: false,
+        mouse: false,
+        fromEditor,
+        scroll: scrollableAt(t.target),
+      });
     },
     { passive: true },
   );
@@ -296,7 +429,7 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
     'touchmove',
     e => {
       const g = gesture;
-      if (!g || g.pull || g.dead) return;
+      if (!g || g.pull || g.mouse || g.dead) return;
       const t = trackedTouch(e);
       if (!t) return;
       g.samples.push({ t: e.timeStamp, x: t.clientX, y: t.clientY });
@@ -304,6 +437,12 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
       const dx = t.clientX - g.x0;
       const dy = t.clientY - g.y0;
       if (!g.claimed) {
+        // A selection that appeared since the touch began (long-press mid-
+        // gesture) hands the touch to its drag handles.
+        if (g.fromEditor && editorSelection()) {
+          g.dead = true;
+          return;
+        }
         const claim = claimGesture(dx, dy, g.scroll, SLOP);
         if (claim === 'undecided') return;
         if (claim === 'scroll') {
@@ -311,13 +450,10 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
           return;
         }
         g.claimed = true;
-        // The touch is a panel drag now: drop the soft keyboard so the graph
-        // it reveals is visible, not the keyboard's letterbox.
-        if (panel.contains(document.activeElement)) (document.activeElement as HTMLElement).blur();
       }
       if (e.cancelable) e.preventDefault(); // ours: no scroll, no selection
-      offset.x = shape(g.base.x + dx);
-      offset.y = shape(g.base.y + dy);
+      offset.x = g.base.x + dx;
+      offset.y = g.base.y + dy;
       paint();
     },
     { passive: false },
@@ -325,27 +461,106 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
 
   const endPanelTouch = (e: TouchEvent) => {
     const g = gesture;
-    if (!g || g.pull) return;
+    if (!g || g.pull || g.mouse) return;
     if (!trackedTouch(e)) return;
     gesture = null;
     if (!g.claimed || g.dead) {
       idle();
       return;
     }
-    if (e.type === 'touchcancel') {
-      settle({ x: 0, y: 0 });
-      return;
-    }
-    const v = releaseVelocity(g.samples, e.timeStamp);
-    if (shouldDismiss(offset, v, baseBox())) dismiss(v);
-    else settle(v);
+    const v = e.type === 'touchcancel' ? { x: 0, y: 0 } : releaseVelocity(g.samples, e.timeStamp);
+    releasePanel(v, g.startOffset);
   };
   panel.addEventListener('touchend', endPanelTouch);
   panel.addEventListener('touchcancel', endPanelTouch);
 
-  // --- the chip: tap to bring the panel back, or drag it back in ---
+  // --- the grip: the same drag for mouse and pen ---
+  //
+  // Touches on the grip take the touch path above (and claim on the first
+  // real move: nothing scrollable lives under it), so only non-touch
+  // pointers are driven from here.
+
+  grip.addEventListener('pointerdown', e => {
+    if (e.pointerType === 'touch' || hidden || gesture || e.button !== 0) return;
+    e.preventDefault(); // a drag, not a text-selection start
+    startPanelGesture(e.pointerId, e.clientX, e.clientY, e.timeStamp, {
+      claimed: true, // grabbing the handle is intent enough
+      mouse: true,
+      fromEditor: false,
+      scroll: null,
+    });
+    try {
+      grip.setPointerCapture(e.pointerId);
+    } catch {} // synthetic events have no active pointer to capture
+  });
+
+  grip.addEventListener('pointermove', e => {
+    const g = gesture;
+    if (!g?.mouse || g.pull || e.pointerId !== g.id) return;
+    g.samples.push({ t: e.timeStamp, x: e.clientX, y: e.clientY });
+    if (g.samples.length > 32) g.samples.shift();
+    offset.x = g.base.x + (e.clientX - g.x0);
+    offset.y = g.base.y + (e.clientY - g.y0);
+    paint();
+  });
+
+  const endGrip = (e: PointerEvent) => {
+    const g = gesture;
+    if (!g?.mouse || g.pull || e.pointerId !== g.id) return;
+    gesture = null;
+    const v = e.type === 'pointercancel' ? { x: 0, y: 0 } : releaseVelocity(g.samples, e.timeStamp);
+    releasePanel(v, g.startOffset);
+  };
+  grip.addEventListener('pointerup', endGrip);
+  grip.addEventListener('pointercancel', endGrip);
+
+  // --- the chip: tap to bring the panel back, or drag to pull it in ---
+
+  /** The drag becomes the panel: park it under the pointer and let it pull. */
+  function beginPull(g: Gesture) {
+    hidden = false;
+    panel.style.visibility = '';
+    hideChip();
+    geo = measure(); // offset is (0,0) while parked, so this reads the rest box
+    const parked = exitRay(geo.rest, exitDir, geo.w, geo.h, geo.vw, geo.vh, EXIT_PAD);
+    g.base = { x: parked.x - geo.rest.x, y: parked.y - geo.rest.y };
+    panel.style.willChange = 'transform, opacity';
+  }
+
+  function releasePull(g: Gesture, v: Vec2, cancelled: boolean) {
+    const open = !cancelled && shouldOpen(offset, v, g.base);
+    if (reduceMotion.matches) {
+      if (open) {
+        offset.x = 0;
+        offset.y = 0;
+        paint();
+        panel.style.willChange = '';
+      } else {
+        offset.x = g.base.x;
+        offset.y = g.base.y;
+        paint();
+        finishDismiss({ x: geo.rest.x + g.base.x, y: geo.rest.y + g.base.y });
+      }
+      return;
+    }
+    if (open) {
+      animateTo({ x: 0, y: 0 }, v, 0.42, 0.8, idle);
+    } else {
+      // Not pulled far enough: park it again and bring the chip back.
+      const parked = { x: geo.rest.x + g.base.x, y: geo.rest.y + g.base.y };
+      animateTo(g.base, v, 0.36, 1, () => finishDismiss(parked), [6, 60]);
+    }
+  }
+
+  /** Set when a mouse drag on the chip just ended: the click that follows a
+   *  drag is not a tap. (Touch drags never produce that click at all.) */
+  let suppressChipClick = false;
 
   chip.addEventListener('click', () => {
+    if (suppressChipClick) {
+      suppressChipClick = false;
+      return;
+    }
     if (gesture?.pull) return;
     present();
   });
@@ -360,9 +575,12 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
         x0: t.clientX,
         y0: t.clientY,
         base: { x: 0, y: 0 },
+        startOffset: { x: 0, y: 0 },
         claimed: false,
         dead: false,
         pull: true,
+        mouse: false,
+        fromEditor: false,
         scroll: null,
         samples: [{ t: e.timeStamp, x: t.clientX, y: t.clientY }],
       };
@@ -374,7 +592,7 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
     'touchmove',
     e => {
       const g = gesture;
-      if (!g?.pull) return;
+      if (!g?.pull || g.mouse) return;
       const t = trackedTouch(e);
       if (!t) return;
       g.samples.push({ t: e.timeStamp, x: t.clientX, y: t.clientY });
@@ -383,14 +601,8 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
       const dy = t.clientY - g.y0;
       if (!g.claimed) {
         if (dx * dx + dy * dy < SLOP * SLOP) return;
-        // The drag becomes the panel: park it under the finger and pull.
         g.claimed = true;
-        g.base = parkedOffset();
-        hidden = false;
-        panel.style.visibility = '';
-        hideChip();
-        dists = exitDistances(baseBox(), EXIT_PAD);
-        panel.style.willChange = 'transform, opacity';
+        beginPull(g);
       }
       if (e.cancelable) e.preventDefault();
       offset.x = shapePull(g.base.x + dx, g.base.x);
@@ -402,30 +614,62 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement): void {
 
   const endChipTouch = (e: TouchEvent) => {
     const g = gesture;
-    if (!g?.pull) return;
+    if (!g?.pull || g.mouse) return;
     if (!trackedTouch(e)) return;
     gesture = null;
     if (!g.claimed) return; // a tap: the click that follows presents
-    const v = releaseVelocity(g.samples, e.timeStamp);
-    const open = e.type !== 'touchcancel' && shouldOpen(offset, v, g.base);
-    if (reduceMotion.matches) {
-      if (open) {
-        offset.x = 0;
-        offset.y = 0;
-        paint();
-        panel.style.willChange = '';
-      } else {
-        offset.x = g.base.x;
-        offset.y = g.base.y;
-        paint();
-        finishDismiss();
-      }
-      return;
-    }
-    if (open) animateTo({ x: 0, y: 0 }, v, 0.42, 0.8, idle);
-    // Not pulled far enough: park it again and bring the chip back.
-    else animateTo(g.base, v, 0.36, 1, finishDismiss, [6, 60]);
+    releasePull(g, releaseVelocity(g.samples, e.timeStamp), e.type === 'touchcancel');
   };
   chip.addEventListener('touchend', endChipTouch);
   chip.addEventListener('touchcancel', endChipTouch);
+
+  chip.addEventListener('pointerdown', e => {
+    if (e.pointerType === 'touch' || !hidden || gesture || e.button !== 0) return;
+    suppressChipClick = false;
+    gesture = {
+      id: e.pointerId,
+      x0: e.clientX,
+      y0: e.clientY,
+      base: { x: 0, y: 0 },
+      startOffset: { x: 0, y: 0 },
+      claimed: false,
+      dead: false,
+      pull: true,
+      mouse: true,
+      fromEditor: false,
+      scroll: null,
+      samples: [{ t: e.timeStamp, x: e.clientX, y: e.clientY }],
+    };
+    try {
+      chip.setPointerCapture(e.pointerId);
+    } catch {}
+  });
+
+  chip.addEventListener('pointermove', e => {
+    const g = gesture;
+    if (!g?.pull || !g.mouse || e.pointerId !== g.id) return;
+    g.samples.push({ t: e.timeStamp, x: e.clientX, y: e.clientY });
+    if (g.samples.length > 32) g.samples.shift();
+    const dx = e.clientX - g.x0;
+    const dy = e.clientY - g.y0;
+    if (!g.claimed) {
+      if (dx * dx + dy * dy < SLOP * SLOP) return;
+      g.claimed = true;
+      beginPull(g);
+    }
+    offset.x = shapePull(g.base.x + dx, g.base.x);
+    offset.y = shapePull(g.base.y + dy, g.base.y);
+    paint();
+  });
+
+  const endChipPointer = (e: PointerEvent) => {
+    const g = gesture;
+    if (!g?.pull || !g.mouse || e.pointerId !== g.id) return;
+    gesture = null;
+    if (!g.claimed) return; // a plain click: the click event presents
+    suppressChipClick = true;
+    releasePull(g, releaseVelocity(g.samples, e.timeStamp), e.type === 'pointercancel');
+  };
+  chip.addEventListener('pointerup', endChipPointer);
+  chip.addEventListener('pointercancel', endChipPointer);
 }

--- a/web/panel-swipe.ts
+++ b/web/panel-swipe.ts
@@ -280,8 +280,8 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement, grip: HTML
       idle();
       return;
     }
-    // A glide with one soft arrival bounce; the finger's speed carries in.
-    animateTo(target, v, 0.45, 0.85, () => {
+    // A glide with a lively arrival bounce; the finger's speed carries in.
+    animateTo(target, v, 0.45, 0.7, () => {
       setCorner(i);
       idle();
     });
@@ -304,7 +304,7 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement, grip: HTML
     }
     panel.style.willChange = 'transform, opacity';
     paint();
-    animateTo({ x: 0, y: 0 }, { x: 0, y: 0 }, 0.42, 0.8, idle);
+    animateTo({ x: 0, y: 0 }, { x: 0, y: 0 }, 0.42, 0.6, idle);
   }
 
   // --- gestures ---
@@ -544,7 +544,7 @@ export function initPanelSwipe(panel: HTMLElement, chip: HTMLElement, grip: HTML
       return;
     }
     if (open) {
-      animateTo({ x: 0, y: 0 }, v, 0.42, 0.8, idle);
+      animateTo({ x: 0, y: 0 }, v, 0.42, 0.6, idle);
     } else {
       // Not pulled far enough: park it again and bring the chip back.
       const parked = { x: geo.rest.x + g.base.x, y: geo.rest.y + g.base.y };

--- a/web/style.css
+++ b/web/style.css
@@ -129,8 +129,56 @@ html, body {
   border: 1px solid var(--panel-border);
   border-radius: 10px;
   box-shadow: 0 4px 20px var(--panel-shadow);
-  padding: 8px;
+  /* Extra top room for the grip strip. */
+  padding: 16px 8px 8px;
 }
+
+/* Corner pinning (panel-swipe.ts): flicking the panel re-anchors it via
+   these classes rather than a transform, so a bottom-pinned panel grows
+   upward as equations are added and rotations keep it glued to its corner. */
+#panel.pin-right {
+  left: auto;
+  right: calc(12px + env(safe-area-inset-right));
+}
+#panel.pin-bottom {
+  top: auto;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  max-height: calc(100% - 24px - env(safe-area-inset-top));
+}
+
+/* The drag handle: a strip along the panel's top edge (under the corner
+   buttons) drawn as an iOS-sheet grabber pill. Touches can drag the panel
+   from anywhere, but for a mouse this is the one drag surface — anywhere
+   else a mouse drag means text selection. */
+#panel-grip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 16px;
+  z-index: 1;
+  cursor: grab;
+  /* No browser pan may start on the handle, so its touchmoves stay
+     cancelable and a drag claims instantly — even mid-edit, when the text
+     below cedes to caret and selection gestures. */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+#panel-grip:active { cursor: grabbing; }
+#panel-grip::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 36px;
+  height: 4px;
+  margin-left: -18px;
+  border-radius: 2px;
+  background: var(--panel-border);
+}
+#panel-grip:hover::after { background: var(--muted); }
 
 #theme-toggle,
 #state-reset {
@@ -350,8 +398,6 @@ html, body {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
-#panel { position: relative; }
-
 #examples {
   /* Never shrinks (the summary row stays visible), but caps itself and scrolls
      internally so an open example tree can't push the panel past its max.
@@ -458,6 +504,16 @@ html, body {
 #panel-chip.shown {
   opacity: 1;
   transform: none;
+}
+/* The chip sits at whichever corner the panel left from (same classes as
+   the panel's pinning, applied together in panel-swipe.ts). */
+#panel-chip.pin-right {
+  left: auto;
+  right: calc(12px + env(safe-area-inset-right));
+}
+#panel-chip.pin-bottom {
+  top: auto;
+  bottom: calc(12px + env(safe-area-inset-bottom));
 }
 @media (prefers-reduced-motion: reduce) {
   #panel-chip { transition: opacity 0.15s ease-out; }

--- a/web/style.css
+++ b/web/style.css
@@ -114,6 +114,11 @@ html, body {
   top: calc(12px + env(safe-area-inset-top));
   left: calc(12px + env(safe-area-inset-left));
   width: 300px;
+  /* Tighter than the blanket pan-x pan-y: nothing in the panel scrolls
+     sideways, so declaring pan-y keeps horizontal touchmoves cancelable and
+     the swipe-to-dismiss drag (panel-swipe.ts) can claim them. Vertical
+     panning stays native for #equations/#examples scrolling. */
+  touch-action: pan-y;
   /* Keep the panel on screen with many equations: cap it at the viewport
      (12px margin top and bottom) and let #equations scroll inside. */
   max-height: calc(100% - 24px - env(safe-area-inset-bottom));
@@ -152,12 +157,16 @@ html, body {
 #state-reset:hover { background: var(--eq-focus); color: var(--muted-hover); }
 
 #equations {
-  /* Scrolls when the list outgrows the panel's max-height; `contain` stops a
-     scroll that hits the end from chaining into a page overscroll bounce. */
+  /* Scrolls when the list outgrows the panel's max-height. `none` (not
+     `contain`) so a scroll that hits the end neither chains into a page
+     bounce nor bounces the list itself — at the edge the browser lets go of
+     the touch, which is what hands "keep swiping past the end" to the
+     panel-dismiss gesture (panel-swipe.ts), the way iOS sheets take over
+     from their scroll views. */
   overflow-y: auto;
   min-height: 0;
   flex: 0 1 auto;
-  overscroll-behavior: contain;
+  overscroll-behavior: none;
   outline: none;
   color: var(--text);
   font: 15px/1.5 ui-monospace, "SF Mono", Menlo, monospace;
@@ -345,11 +354,13 @@ html, body {
 
 #examples {
   /* Never shrinks (the summary row stays visible), but caps itself and scrolls
-     internally so an open example tree can't push the panel past its max. */
+     internally so an open example tree can't push the panel past its max.
+     `none` for the same reason as #equations: the swipe-dismiss gesture picks
+     up where the scroll ends. */
   flex: none;
   max-height: 40%;
   overflow-y: auto;
-  overscroll-behavior: contain;
+  overscroll-behavior: none;
   border-top: 1px solid var(--divider);
   margin-top: 4px;
   padding: 4px;
@@ -410,3 +421,44 @@ html, body {
   text-overflow: ellipsis;
 }
 .ex-item:hover code { color: var(--ex-code-hover); }
+
+/* The panel's collapsed form: after a swipe dismisses the panel
+   (panel-swipe.ts), this chip pops into its corner. Tapping springs the
+   panel back; dragging pulls it back in under the finger. */
+#panel-chip {
+  position: absolute;
+  top: calc(12px + env(safe-area-inset-top));
+  left: calc(12px + env(safe-area-inset-left));
+  width: 46px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid var(--panel-border);
+  border-radius: 11px;
+  background: var(--panel-bg);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 4px 20px var(--panel-shadow);
+  color: var(--text);
+  font: 15px/1 ui-monospace, "SF Mono", Menlo, monospace;
+  cursor: pointer;
+  /* A drag handle as much as a button: no browser pan may start on it, so
+     its touchmoves stay cancelable for the pull-open gesture. */
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  -webkit-user-select: none;
+  /* Hidden pose; .shown transitions from it, popping the chip in as the
+     panel clears the screen. A transition (not an animation) so JS can
+     stage the flip: unhide, reflow, then add .shown. */
+  opacity: 0;
+  transform: scale(0.5);
+  transition:
+    transform 0.26s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.18s ease-out;
+}
+#panel-chip.shown {
+  opacity: 1;
+  transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  #panel-chip { transition: opacity 0.15s ease-out; }
+}

--- a/web/style.css
+++ b/web/style.css
@@ -8,6 +8,15 @@
    the caret, text selection, and the panel's internal scrolling alone. */
 * { touch-action: pan-x pan-y; }
 
+/* The page is an app, not a document: chrome, buttons and the graph never
+   select (no blue sweep on select-all, no long-press selection on labels).
+   Only real text surfaces opt back in — the equation editor and the slider
+   bound fields below. Inherited, so those two opt-ins cover their subtrees. */
+body {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 /* Light theme (default). The dark overrides live in [data-theme="dark"] below;
    the JS theme switch flips data-theme on <html>, so every panel color moves
    with the WebGL background in one place. */
@@ -162,8 +171,6 @@ html, body {
      cancelable and a drag claims instantly — even mid-edit, when the text
      below cedes to caret and selection gestures. */
   touch-action: none;
-  user-select: none;
-  -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;
 }
 #panel-grip:active { cursor: grabbing; }
@@ -220,6 +227,10 @@ html, body {
   font: 15px/1.5 ui-monospace, "SF Mono", Menlo, monospace;
   padding: 2px 0;
   caret-color: var(--text);
+  /* Opt back out of the body's user-select: none — explicitly, because on
+     iOS a non-selectable ancestor otherwise leaves the editable untappable. */
+  user-select: text;
+  -webkit-user-select: text;
 }
 .eq-line {
   position: relative;
@@ -314,6 +325,9 @@ html, body {
   text-align: center;
   appearance: textfield;
   -moz-appearance: textfield;
+  /* Editable despite sitting inside a non-selectable .eq-widget. */
+  user-select: text;
+  -webkit-user-select: text;
 }
 .eq-slider-bound:focus { color: var(--bound-focus); }
 .eq-slider-bound::-webkit-outer-spin-button,
@@ -355,7 +369,6 @@ html, body {
   font: italic 12px ui-sans-serif, system-ui;
   color: var(--summary);
   cursor: pointer;
-  user-select: none;
 }
 .eq-curve-toggle input {
   margin: 0;
@@ -430,7 +443,6 @@ html, body {
 #examples > summary {
   color: var(--muted);
   cursor: pointer;
-  user-select: none;
   padding: 2px;
 }
 #examples > summary:hover { color: var(--muted-hover); }
@@ -440,7 +452,6 @@ html, body {
 #examples details > summary {
   color: var(--summary);
   cursor: pointer;
-  user-select: none;
   padding: 2px;
   font-weight: 500;
 }
@@ -490,8 +501,6 @@ html, body {
      its touchmoves stay cancelable for the pull-open gesture. */
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
-  user-select: none;
-  -webkit-user-select: none;
   /* Hidden pose; .shown transitions from it, popping the chip in as the
      panel clears the screen. A transition (not an animation) so JS can
      stage the flip: unhide, reflow, then add .shown. */


### PR DESCRIPTION
On a phone the panel covers most of the graph with no way to clear it.
Now it dismisses the way an iOS sheet does: pinned to the finger from
the first move (up, left, or diagonally), rubber-banding in directions
that can't dismiss, committing by projected momentum — a slow drag past
halfway or a flick both work — and leaving along the throw line on a
spring seeded with the release velocity, so motion stays continuous
through the release and the panel can be caught mid-flight. A y= chip
takes its corner: tap to spring the panel back, or drag to pull it in.

The physics and decision math (rubber band, velocity window, momentum
projection, exit ray, spring integrator, scroll-vs-swipe claim) is
lib/fling.ts under vitest; web/panel-swipe.ts owns the touch events and
the arbitration with the list's own scrolling, which now hands over at
the scroll edge (overscroll-behavior none) like a sheet under a scroll
view. The gutter's color/collapse action moves to click for touch
pointers so a swipe starting on the dot can't also recolor the row.
scripts/swipe-test.ts drives the real gesture in headless Chromium via
CDP trusted touch input.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XD2joiVp6aS7AaLbDXEmWC