### PR TITLE
Worker VM: use realPow so previews agree with the app on odd roots

### DIFF
--- a/worker/vm.test.ts
+++ b/worker/vm.test.ts
@@ -22,6 +22,18 @@ describe('expression stack machine', () => {
     }
   });
 
+  it('matches the AST evaluator on negative bases with fractional exponents', () => {
+    const e = parseExpr('x^(1/3)');
+    const prog = compileProg(e, new Map([['x', 0]]));
+    const stack = new Float64Array(prog.depth);
+    expect(run(prog, [-8], stack)).toBeCloseTo(evaluate(e, { x: -8 }), 12);
+    expect(run(prog, [-8], stack)).toBeCloseTo(-2, 12);
+    expect(run(prog, [8], stack)).toBeCloseTo(2, 12);
+    const even = parseExpr('x^(1/2)');
+    const evenProg = compileProg(even, new Map([['x', 0]]));
+    expect(run(evenProg, [-4], new Float64Array(evenProg.depth))).toBeNaN();
+  });
+
   it('reports the true stack depth for deeply right-nested expressions', () => {
     // 1+(1+(1+(... x ...))) nests 80 deep — more than any fixed small stack.
     const deep = '1+('.repeat(80) + 'x' + ')'.repeat(80);

--- a/worker/vm.ts
+++ b/worker/vm.ts
@@ -5,7 +5,7 @@
  * sample is too slow and Workers forbid dynamic codegen (`new Function`), so
  * expressions compile once to opcode arrays run by a small stack machine.
  */
-import { type Expr, erf, ineqComparisons, normalcdf, normalpdf } from '../lib/expr.ts';
+import { type Expr, erf, ineqComparisons, normalcdf, normalpdf, realPow } from '../lib/expr.ts';
 
 const enum Op { Const, Var, Add, Sub, Mul, Div, Pow, Neg, Fn1, Fn2, Fn3, Lt, Le, Gt, Ge, Sel }
 
@@ -154,7 +154,7 @@ export function run(p: Prog, vars: ArrayLike<number>, stack: Float64Array): numb
       case Op.Sub: sp--; stack[sp - 1] -= stack[sp]; break;
       case Op.Mul: sp--; stack[sp - 1] *= stack[sp]; break;
       case Op.Div: sp--; stack[sp - 1] /= stack[sp]; break;
-      case Op.Pow: sp--; stack[sp - 1] = Math.pow(stack[sp - 1], stack[sp]); break;
+      case Op.Pow: sp--; stack[sp - 1] = realPow(stack[sp - 1], stack[sp]); break;
       case Op.Neg: stack[sp - 1] = -stack[sp - 1]; break;
       case Op.Fn1: stack[sp - 1] = FN1_TABLE[arg](stack[sp - 1]); break;
       case Op.Fn2: sp--; stack[sp - 1] = FN2_TABLE[arg](stack[sp - 1], stack[sp]); break;


### PR DESCRIPTION
## Summary

#82 fixed negative-base fractional exponents (`(-8)^(1/3) = -2`) in the CPU evaluator and GLSL, but the worker's stack VM — which renders og preview curves and backs MCP validation — still used a bare `Math.pow`, so previews disagreed with the app on those curves. This wires the exported `realPow` into the VM's `Op.Pow`.

## Test plan

- [x] New VM test: `x^(1/3)` at `x = -8` matches the AST evaluator (`-2`), positive bases unchanged, and `(-4)^(1/2)` stays NaN
- [x] `npx vitest run` — 627 tests pass
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)