### PR TITLE
Drag to resize the equations panel

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -56,6 +56,10 @@
          drag (a mouse drag over text means selection): grab here to move the
          panel between corners or flick it off-screen. See panel-swipe.ts. -->
     <div id="panel-grip" title="Drag to move the panel; flick it off-screen to hide it" aria-hidden="true"></div>
+    <!-- Resize strip on the outer vertical edge (the pinned edge stays
+         anchored). Drag to change the panel width; double-click to reset.
+         See panel-resize.ts. -->
+    <div id="panel-resize" title="Drag to resize the panel; double-click to reset" aria-hidden="true"></div>
     <button id="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">☾</button>
     <button id="state-reset" type="button" aria-label="Restart the simulation" title="Restart the simulation" hidden>↻</button>
     <div id="equations" contenteditable="true" role="textbox" aria-multiline="true" aria-label="Equations, one per line" spellcheck="false" autocapitalize="off" autocorrect="off" enterkeyhint="enter"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -58,8 +58,12 @@
     <div id="panel-grip" title="Drag to move the panel; flick it off-screen to hide it" aria-hidden="true"></div>
     <!-- Resize strip on the outer vertical edge (the pinned edge stays
          anchored). Drag to change the panel width; double-click to reset.
-         See panel-resize.ts. -->
-    <div id="panel-resize" title="Drag to resize the panel; double-click to reset" aria-hidden="true"></div>
+         Also an ARIA window splitter: focusable, arrows resize, Home/End
+         jump to min/max, Enter resets. panel-resize.ts keeps the aria-value*
+         attributes current. -->
+    <div id="panel-resize" role="separator" aria-orientation="vertical" tabindex="0"
+         aria-label="Resize the equations panel"
+         title="Drag to resize the panel; double-click to reset"></div>
     <button id="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">☾</button>
     <button id="state-reset" type="button" aria-label="Restart the simulation" title="Restart the simulation" hidden>↻</button>
     <div id="equations" contenteditable="true" role="textbox" aria-multiline="true" aria-label="Equations, one per line" spellcheck="false" autocapitalize="off" autocorrect="off" enterkeyhint="enter"></div>

--- a/web/main.ts
+++ b/web/main.ts
@@ -63,6 +63,7 @@ import {
   niceSpacing,
 } from './render2d.ts';
 import { type Camera3D, Renderer3D, type Scene3D, cameraBoxR, drawLabels3D } from './render3d.ts';
+import { initPanelResize } from './panel-resize.ts';
 import { initPanelSwipe } from './panel-swipe.ts';
 import { initTheme, onThemeChange, theme, toggleTheme } from './theme.ts';
 
@@ -2776,6 +2777,13 @@ initPanelSwipe(
   document.getElementById('panel-chip')!,
   document.getElementById('panel-grip')!,
   listEl,
+);
+
+// Drag the strip on the panel's outer vertical edge to resize it (the width
+// persists; double-click resets).
+initPanelResize(
+  document.getElementById('panel')!,
+  document.getElementById('panel-resize')!,
 );
 
 // --- boot ---

--- a/web/panel-resize.ts
+++ b/web/panel-resize.ts
@@ -1,0 +1,73 @@
+/**
+ * Drag-to-resize for the equations panel.
+ *
+ * A grab strip along the panel's outer vertical edge — the edge facing away
+ * from the pinned corner, so the anchored edge stays put — drags the panel
+ * wider or narrower. The chosen width persists across visits; double-click
+ * snaps back to the stylesheet default. Width is clamped so the panel always
+ * fits on screen, and a CSS max-width re-clamps a remembered width on a
+ * screen narrower than the last visit.
+ *
+ * Touch drags on the strip are resizes, never panel throws: the strip stops
+ * its touchstart from reaching panel-swipe.ts, and its touch-action: none
+ * keeps the browser from panning so pointermoves keep arriving.
+ */
+
+/** The panel width the user last chose, kept across visits. */
+const WIDTH_KEY = 'eq-panel-width';
+/** Narrow enough for small screens, wide enough that a row stays usable. */
+const MIN_WIDTH = 220;
+/** Screen margin on each side while resizing (matches the panel's CSS). */
+const MARGIN = 12;
+
+export function initPanelResize(panel: HTMLElement, handle: HTMLElement): void {
+  const clampWidth = (w: number) =>
+    Math.round(Math.min(Math.max(w, MIN_WIDTH), document.documentElement.clientWidth - 2 * MARGIN));
+
+  // Restore the remembered width, re-clamped: the screen may have shrunk
+  // since it was saved.
+  try {
+    const w = Number(localStorage.getItem(WIDTH_KEY));
+    if (w >= MIN_WIDTH) panel.style.width = `${clampWidth(w)}px`;
+  } catch {}
+
+  let drag: { id: number; x0: number; w0: number } | null = null;
+
+  handle.addEventListener('pointerdown', e => {
+    if (drag || e.button !== 0) return;
+    e.preventDefault(); // a drag, not a text-selection start
+    drag = { id: e.pointerId, x0: e.clientX, w0: panel.getBoundingClientRect().width };
+    try {
+      handle.setPointerCapture(e.pointerId);
+    } catch {} // synthetic events have no active pointer to capture
+  });
+
+  handle.addEventListener('pointermove', e => {
+    if (!drag || e.pointerId !== drag.id) return;
+    // The pinned edge stays anchored, so the outer edge follows the pointer:
+    // pinned left, dragging right widens; pinned right, mirrored.
+    const dx = e.clientX - drag.x0;
+    const dw = panel.classList.contains('pin-right') ? -dx : dx;
+    panel.style.width = `${clampWidth(drag.w0 + dw)}px`;
+  });
+
+  const end = (e: PointerEvent) => {
+    if (!drag || e.pointerId !== drag.id) return;
+    drag = null;
+    try {
+      localStorage.setItem(WIDTH_KEY, String(parseFloat(panel.style.width)));
+    } catch {} // private mode: the width just won't stick across visits
+  };
+  handle.addEventListener('pointerup', end);
+  handle.addEventListener('pointercancel', end);
+
+  handle.addEventListener('dblclick', () => {
+    panel.style.width = '';
+    try {
+      localStorage.removeItem(WIDTH_KEY);
+    } catch {}
+  });
+
+  // Keep panel-swipe.ts from treating a resize touch as a panel drag.
+  handle.addEventListener('touchstart', e => e.stopPropagation(), { passive: true });
+}

--- a/web/panel-resize.ts
+++ b/web/panel-resize.ts
@@ -8,6 +8,12 @@
  * fits on screen, and a CSS max-width re-clamps a remembered width on a
  * screen narrower than the last visit.
  *
+ * The strip is also an ARIA window splitter (role="separator", focusable):
+ * arrow keys resize — the arrow moves the edge in that screen direction, so
+ * the panel's pin side decides whether that widens or narrows — Home/End
+ * jump to the min/max width, and Enter resets to the default. The
+ * aria-value* attributes track the current/min/max width in pixels.
+ *
  * Touch drags on the strip are resizes, never panel throws: the strip stops
  * its touchstart from reaching panel-swipe.ts, and its touch-action: none
  * keeps the browser from panning so pointermoves keep arriving.
@@ -19,17 +25,46 @@ const WIDTH_KEY = 'eq-panel-width';
 const MIN_WIDTH = 220;
 /** Screen margin on each side while resizing (matches the panel's CSS). */
 const MARGIN = 12;
+/** Arrow-key resize step (px). */
+const KEY_STEP = 16;
 
 export function initPanelResize(panel: HTMLElement, handle: HTMLElement): void {
-  const clampWidth = (w: number) =>
-    Math.round(Math.min(Math.max(w, MIN_WIDTH), document.documentElement.clientWidth - 2 * MARGIN));
+  const maxWidth = () => document.documentElement.clientWidth - 2 * MARGIN;
+  const clampWidth = (w: number) => Math.round(Math.min(Math.max(w, MIN_WIDTH), maxWidth()));
+
+  const syncAria = () => {
+    handle.setAttribute('aria-valuemin', String(MIN_WIDTH));
+    handle.setAttribute('aria-valuemax', String(Math.round(maxWidth())));
+    handle.setAttribute('aria-valuenow', String(Math.round(panel.getBoundingClientRect().width)));
+  };
+
+  const save = () => {
+    try {
+      localStorage.setItem(WIDTH_KEY, String(Math.round(panel.getBoundingClientRect().width)));
+    } catch {} // private mode: the width just won't stick across visits
+  };
+
+  const setWidth = (w: number) => {
+    panel.style.width = `${clampWidth(w)}px`;
+    syncAria();
+  };
+
+  /** Back to the stylesheet default, forgetting the stored width. */
+  const reset = () => {
+    panel.style.width = '';
+    try {
+      localStorage.removeItem(WIDTH_KEY);
+    } catch {}
+    syncAria();
+  };
 
   // Restore the remembered width, re-clamped: the screen may have shrunk
   // since it was saved.
   try {
     const w = Number(localStorage.getItem(WIDTH_KEY));
-    if (w >= MIN_WIDTH) panel.style.width = `${clampWidth(w)}px`;
+    if (w >= MIN_WIDTH) setWidth(w);
   } catch {}
+  syncAria();
 
   let drag: { id: number; x0: number; w0: number } | null = null;
 
@@ -48,25 +83,43 @@ export function initPanelResize(panel: HTMLElement, handle: HTMLElement): void {
     // pinned left, dragging right widens; pinned right, mirrored.
     const dx = e.clientX - drag.x0;
     const dw = panel.classList.contains('pin-right') ? -dx : dx;
-    panel.style.width = `${clampWidth(drag.w0 + dw)}px`;
+    setWidth(drag.w0 + dw);
   });
 
   const end = (e: PointerEvent) => {
     if (!drag || e.pointerId !== drag.id) return;
     drag = null;
-    try {
-      localStorage.setItem(WIDTH_KEY, String(parseFloat(panel.style.width)));
-    } catch {} // private mode: the width just won't stick across visits
+    save();
   };
   handle.addEventListener('pointerup', end);
   handle.addEventListener('pointercancel', end);
 
-  handle.addEventListener('dblclick', () => {
-    panel.style.width = '';
-    try {
-      localStorage.removeItem(WIDTH_KEY);
-    } catch {}
+  handle.addEventListener('dblclick', reset);
+
+  handle.addEventListener('keydown', e => {
+    // Arrows move the edge in that screen direction: away from the pinned
+    // side widens (same mapping the pointer drag uses).
+    const edgeStep = e.key === 'ArrowRight' ? KEY_STEP : e.key === 'ArrowLeft' ? -KEY_STEP : 0;
+    if (edgeStep) {
+      const dw = panel.classList.contains('pin-right') ? -edgeStep : edgeStep;
+      setWidth(panel.getBoundingClientRect().width + dw);
+      save();
+    } else if (e.key === 'Home') {
+      setWidth(MIN_WIDTH);
+      save();
+    } else if (e.key === 'End') {
+      setWidth(maxWidth());
+      save();
+    } else if (e.key === 'Enter') {
+      reset();
+    } else {
+      return;
+    }
+    e.preventDefault();
   });
+
+  // The max (and the clamped current width) move with the viewport.
+  window.addEventListener('resize', syncAria);
 
   // Keep panel-swipe.ts from treating a resize touch as a panel drag.
   handle.addEventListener('touchstart', e => e.stopPropagation(), { passive: true });

--- a/web/style.css
+++ b/web/style.css
@@ -131,6 +131,8 @@ html, body {
   /* Keep the panel on screen with many equations: cap it at the viewport
      (12px margin top and bottom) and let #equations scroll inside. */
   max-height: calc(100% - 24px - env(safe-area-inset-bottom));
+  /* A remembered width (panel-resize.ts) from a wider screen re-clamps here. */
+  max-width: calc(100% - 24px - env(safe-area-inset-left) - env(safe-area-inset-right));
   display: flex;
   flex-direction: column;
   background: var(--panel-bg);
@@ -186,6 +188,39 @@ html, body {
   background: var(--panel-border);
 }
 #panel-grip:hover::after { background: var(--muted); }
+
+/* The resize strip (panel-resize.ts): straddles the panel's outer vertical
+   edge — the one away from the pinned corner — below the grip. A grabber
+   pill like the grip's appears on hover; the strip itself stays invisible. */
+#panel-resize {
+  position: absolute;
+  top: 16px;
+  bottom: 0;
+  right: -5px;
+  width: 10px;
+  z-index: 1;
+  cursor: ew-resize;
+  /* No browser pan may start on the strip: its pointermoves keep arriving
+     for the whole drag, same deal as the grip. */
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+}
+#panel.pin-right #panel-resize {
+  right: auto;
+  left: -5px;
+}
+#panel-resize::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 36px;
+  margin: -18px 0 0 -2px;
+  border-radius: 2px;
+}
+#panel-resize:hover::after,
+#panel-resize:active::after { background: var(--panel-border); }
 
 #theme-toggle,
 #state-reset {

--- a/web/style.css
+++ b/web/style.css
@@ -221,6 +221,10 @@ html, body {
 }
 #panel-resize:hover::after,
 #panel-resize:active::after { background: var(--panel-border); }
+/* Keyboard focus shows the pill in the accent color instead of the default
+   outline, which would trace the whole off-edge strip. */
+#panel-resize { outline: none; }
+#panel-resize:focus-visible::after { background: var(--accent); }
 
 #theme-toggle,
 #state-reset {


### PR DESCRIPTION
## What

Closes #47 (the 2011 "resize the equation bar" request, reinterpreted for the current UI): the equations panel is now resizable. A grab strip along the panel's **outer** vertical edge — the edge facing away from the pinned corner, so the anchored edge stays put — drags the panel wider or narrower with any pointer. A grabber pill (matching the move-grip idiom) appears on hover.

- The chosen width persists across visits (`eq-panel-width`), re-clamped on load if the screen shrank; a CSS `max-width` also guards it.
- Width is clamped to [220px, viewport − margins] during the drag.
- Double-click the strip to snap back to the stylesheet default.
- When the panel is pinned right, the strip mirrors to the left edge and the drag direction flips, so the panel always grows away from its corner.
- Touch drags on the strip are resizes, never panel throws: the strip stops its touchstart from reaching panel-swipe.ts, and `touch-action: none` keeps its pointermoves flowing.

## Test plan

- [x] `npx vitest run` (629) and `npm run typecheck` clean
- [x] Verified in Chrome against the dev server: drag right edge 300 → 460px; width restored after reload; max clamp = viewport − 24px; min clamp = 220px; double-click resets to 300px and clears storage; pinned right, the handle flips to the left edge, dragging left widens, and the right edge stays anchored; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)