### PR TITLE
Examples menu: opening an example replaces the whole document

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -2210,15 +2210,13 @@ const EXAMPLES: Array<[string, Array<[string, string]>]> = [
   ]],
 ];
 
-function insertExample(text: string) {
+function openExample(text: string) {
   pushUndo(null);
-  // Fill the trailing empty line (or append) so existing equations stay.
-  // Multi-row examples separate rows with ';' (the same separator as the hash).
-  for (const part of splitStatements(text)) {
-    let eq = equations[equations.length - 1];
-    if (!eq || eq.text.trim()) eq = addEquation('');
-    eq.text = part.trim();
-  }
+  // An example is a fresh start: it replaces the whole document (undo brings
+  // the old one back). Multi-row examples separate rows with ';' (the same
+  // separator as the hash).
+  equations.length = 0;
+  for (const part of splitStatements(text)) addEquation(part.trim());
   recompileAll();
   saveUrl();
   renderAll();
@@ -2239,7 +2237,7 @@ function buildExamplesMenu() {
       const code = document.createElement('code');
       code.textContent = text;
       item.append(code);
-      item.addEventListener('click', () => insertExample(text));
+      item.addEventListener('click', () => openExample(text));
       group.append(item);
     }
     list.append(group);


### PR DESCRIPTION
## What changed

Clicking an entry in the examples menu now replaces the entire document with that example's rows. Previously `insertExample` filled the trailing empty row and appended, so the example landed mixed in with whatever equations were already there.

The new behavior mirrors `loadFromUrl`: clear the equation list, add one row per `;`-separated statement, recompile, save the URL. Renamed the function to `openExample` to match the semantics (one call site).

## Why

An example is a fresh start — mixing its rows into an existing document produced confusing composites (stray sliders, clashing view specs) rather than the curated scene the menu entry promises.

## Notes for review

- `pushUndo(null)` still runs first, so **undo restores the replaced document** — verified in the browser (Cmd+Z brought back the prior equations).
- Verified in the dev server: loaded `y = x^2; y = x + 1`, clicked the multi-row *jacobian counterexample* example → document became exactly its 3 rows, URL rewrote to the `/g/…` form, no console errors.
- Typecheck and all 643 tests pass (the function is app-glue in `web/main.ts`; no unit tests reference it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)